### PR TITLE
Added AsciiDoc link checking support

### DIFF
--- a/lib/extract-asciidoc-hyperlinks.js
+++ b/lib/extract-asciidoc-hyperlinks.js
@@ -1,0 +1,100 @@
+import fs from "fs";
+import readline from "readline";
+
+function extractAsciiDocLinks(filePath) {
+  return new Promise((resolve) => {
+    const links = [];
+
+    const rl = readline.createInterface({
+      input: fs.createReadStream(filePath),
+      crlfDelay: Infinity,
+    });
+
+    let lineNumber = 0;
+
+    // Updated regular expression to match only the URLs in the specified formats
+    const urlRegex =
+      /(?:https?|ftp|irc|mailto):\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+
+    rl.on("line", (line) => {
+      lineNumber++;
+
+      let match;
+      while ((match = urlRegex.exec(line)) !== null) {
+        const url = match[0].replace(/^link:/, ""); // Remove 'link:' prefix if present
+        const position = {
+          start: { line: lineNumber, column: match.index, offset: match.index },
+          end: {
+            line: lineNumber,
+            column: match.index + match[0].length,
+            offset: match.index + match[0].length,
+          },
+        };
+
+        // Updated logic to extract the optional link text from the line
+        let title = null;
+        let children = [];
+        const linkTextRegex = /\[([^\]]+)\]/g; // Regular expression to match the link text inside brackets
+        linkTextRegex.lastIndex = position.end.offset; // Set the starting index to the end of the URL
+        const linkTextMatch = linkTextRegex.exec(line); // Try to find a link text after the URL
+        if (linkTextMatch) {
+          // If a link text is found, use it as the title and children value
+          title = linkTextMatch[1];
+          children.push({
+            type: "text",
+            value: title,
+            position: {
+              start: {
+                line: lineNumber,
+                column: linkTextMatch.index + 1,
+                offset: linkTextMatch.index + 1,
+              },
+              end: {
+                line: lineNumber,
+                column: linkTextMatch.index + linkTextMatch[0].length - 1,
+                offset: linkTextMatch.index + linkTextMatch[0].length - 1,
+              },
+            },
+          });
+          // Update the position end to include the link text
+          position.end.column += linkTextMatch[0].length;
+          position.end.offset += linkTextMatch[0].length;
+        } else {
+          // If no link text is found, use the URL as the children value
+          children.push({
+            type: "text",
+            value: url,
+            position: {
+              start: {
+                line: lineNumber,
+                column: match.index + 1,
+                offset: position.start.offset + 1,
+              },
+              end: {
+                line: lineNumber,
+                column: match.index + url.length + 1,
+                offset: position.start.offset + url.length + 1,
+              },
+            },
+          });
+        }
+
+        const linkNode = {
+          type: "link",
+          title: title,
+          url: url,
+          children: children,
+          position: position,
+        };
+
+        links.push(linkNode);
+      }
+    });
+
+    rl.on("close", () => {
+      resolve(links);
+    });
+  });
+}
+
+export { extractAsciiDocLinks };

--- a/lib/prepare-file-list.js
+++ b/lib/prepare-file-list.js
@@ -54,7 +54,6 @@ function removeDuplicates(array) {
  * @returns {string[]} An array of file paths.
  */
 function prepareFilesList(config) {
-  // Read and parse the YAML file into a JavaScript object
   try {
     let files = [];
     let specifiedFiles = config.files
@@ -77,9 +76,17 @@ function prepareFilesList(config) {
     // Check if specified files exist and add them to the list
     specifiedFiles.forEach((file) => {
       const filePath = resolve(process.cwd(), file);
+      const fileExtension = path.extname(filePath).substring(1); // Get the file extension without the leading dot
+
       if (existsSync(filePath)) {
         if (!files.includes(filePath)) {
-          files.push(filePath);
+          if (fileExtensions.includes(fileExtension)) {
+            files.push(filePath);
+          } else {
+            console.warn(
+              `ℹ️ The file "${file}" specified in the config does not have the correct extension. Use "fileExtensions" to configure the extensions.`
+            );
+          }
         } else {
           console.warn(
             `ℹ️ The file "${file}" specified in the config is already included.`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Added AsciiDoc support with some caveats:
- Users can check hyperlinks in AsciiDoc files as long as the file extension is one of the GitHub supported extensions `.asciidoc`, `.adoc`, and `.asc`. 
- Defaults to checking MarkDown otherwise.
- Only check URLs and doesn't work for relative links.