### PR TITLE
Refactor extractMarkdownHyperlinks function to handle ignore patterns correctly

### DIFF
--- a/lib/extract-markdown-hyperlinks.js
+++ b/lib/extract-markdown-hyperlinks.js
@@ -19,19 +19,19 @@ import { visit } from "unist-util-visit";
 
 function extractMarkdownHyperlinks(markdownText, options = {}) {
   const { ignorePatterns = [], replacementPatterns = [], baseURL } = options;
-
   const tree = unified()
     .use(remarkParse)
     .use(remarkGfm)
     .parse(markdownText);
 
   const links = [];
-  // Use 'heading', 'link', 'linkReference', 'definition', 'imageReference' in future.
   visit(tree, ['link', 'definition'], (node) => {
     let { url } = node;
-
     // Skip link checking if it matches any ignore pattern
-    if (ignorePatterns.some(pattern => pattern.test(url))) {
+    if (ignorePatterns.some(({ pattern }) => {
+      const regex = new RegExp(pattern);
+      return regex.test(url);
+    })) {
       return;
     }
 
@@ -41,15 +41,13 @@ function extractMarkdownHyperlinks(markdownText, options = {}) {
     }
 
     // Replace link URL based on replacement patterns
-    let replacedUrl = url;
     replacementPatterns.forEach(({ pattern, replacement }) => {
-      replacedUrl = replacedUrl.replace(pattern, replacement);
+      url = url.replace(new RegExp(pattern), replacement);
     });
-    node.url = replacedUrl;
+    node.url = url;
 
     links.push(node);
   });
-
   return links;
 }
 

--- a/linkspector.js
+++ b/linkspector.js
@@ -127,7 +127,7 @@ export async function* linkspector(configFile) {
       astNodes = await extractAsciiDocLinks(file);
     } else {
       const fileContent = readFileSync(file, "utf8");
-      astNodes = extractMarkdownHyperlinks(fileContent);
+      astNodes = extractMarkdownHyperlinks(fileContent, config);
     }
 
     // Get unique hyperlinks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",


### PR DESCRIPTION
Based on https://github.com/UmbrellaDocs/linkspector/issues/16#issuecomment-1908122988

Thank you @CsatariGergely