### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+FROM node:lts-bookworm-slim
+
+# The base name of the npm package
+ARG LINKSPECTOR_NAME=@umbrelladocs/linkspector
+# Use the argument below to select version to install, e.g.:
+# docker build --build-arg LINKSPECTOR_VERSION=0.2.7 -t umbrelladocs/linkspector .
+ARG LINKSPECTOR_VERSION=latest
+# Use the argument below the specify full package name to install,
+# empty value installs current directory, e.g.:
+# docker build --build-arg LINKSPECTOR_PACKAGE= -t umbrelladocs/linkspector .
+ARG LINKSPECTOR_PACKAGE=${LINKSPECTOR_NAME}@${LINKSPECTOR_VERSION}
+
+# Set default user
+ENV USER=node
+
+# Set installation location for node packages
+ENV NPM_GLOBAL=/home/${USER}/.npm-global
+ENV PATH=${NPM_GLOBAL}/bin:$PATH
+
+# Install chromium instead of puppeteer chrome
+# as puppeteer does not provide arm64
+# https://github.com/puppeteer/puppeteer/issues/7740
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium.wrapper
+
+# Install linkspector dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    chromium \
+    curl \
+    git \
+    upower \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create app directory for mounting host files
+RUN mkdir /app && chown ${USER}:${USER} /app
+
+# chromium in order to start either needs dbus https://github.com/puppeteer/puppeteer/issues/11028
+# or skip dbus by using --remote-debugging-port=0 (any free port) https://github.com/nodejs/help/issues/3220#issuecomment-1228342313
+# Additionally, allow chromium to start without elevated capabilities needed to start the sandbox
+# See https://github.com/puppeteer/puppeteer/issues/5505
+RUN echo /usr/bin/chromium \
+         --no-sandbox \
+         --headless=new \
+         --disable-gpu \
+         --enable-chrome-browser-cloud-management \
+         --remote-debugging-port=0 \
+         > /usr/bin/chromium.wrapper
+RUN chmod ugo+x /usr/bin/chromium.wrapper
+
+# Install linkspector as node user
+USER ${USER}
+WORKDIR /home/${USER}
+RUN npm config set prefix ${NPM_GLOBAL}
+COPY --chown=${USER}:${USER} lib lib
+COPY --chown=${USER}:${USER} *.js *.json test ./
+# npm ci does not support --global
+# https://github.com/npm/cli/issues/7224
+RUN if test -z ${LINKSPECTOR_PACKAGE}; then npm ci; fi && npm install --global ${LINKSPECTOR_PACKAGE}
+
+WORKDIR /app
+
+# Run sanity checks
+RUN npm list --global
+RUN linkspector --version
+RUN linkspector check

--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ To check hyperlinks in your markup language files, follow these steps:
     linkspector check --json
     ```
 
-1. Linkspector starts checking the hyperlinks in your files based on the configuration provided in the configuration file or using the default configuration. It then displays the results in your terminal.
-
-1. After the check is complete, Linkspector provides a summary of the results. If any dead links are found, they are listed in the terminal, along with their status codes and error messages.
-
-1. If no dead links are found, Linkspector displays a success message, indicating that all links are working.
-
 ## Configuration
 
 Linkspector uses a configuration file named `.linkspector.yml` to customize its behavior. If this file is not found in the current directory when the program is run, Linkspector displays a message saying "Configuration file not found. Using default configuration." and uses a default configuration.
@@ -226,6 +220,40 @@ If there are no errors, linkspector shows the following message:
 ```
 ✨ Success: All hyperlinks in the specified files are valid.
 ```
+
+## Using Linkspector with Docker
+
+To use Linkspector with Docker, follow these steps:
+
+1. Clone the Linkspector repository to your local machine and switch to the cloned directory:
+   ```bash
+   git clone git@github.com:UmbrellaDocs/linkspector.git
+   cd linkspector
+   ```
+1. Build the docker image locally, while being at the root (`.`) of this project:
+   ```bash
+   docker build --no-cache --pull --build-arg LINKSPECTOR_PACKAGE= -t umbrelladocs/linkspector .
+   ```
+
+1. To perform a check using the default configuration, while being at the root (`$PWD`) of the project to be checked:
+   ```bash
+   docker run --rm -it -v $PWD:/app \
+          --name linkspector umbrelladocs/linkspector \
+          bash -c 'linkspector check'
+   ```
+
+   To specify a custom configuration file path:
+   ```bash
+   docker run --rm -it -v $PWD:/app -v $PWD/custom-config.yml:/path/to/custom-config.yml \
+          --name linkspector umbrelladocs/linkspector \
+          bash -c 'linkspector check -c /path/to/custom-config.yml'
+   ```
+
+1. Linkspector starts checking the hyperlinks in your files based on the configuration provided in the configuration file or using the default configuration. It then displays the results in your terminal.
+
+1. After the check is complete, Linkspector provides a summary of the results. If any dead links are found, they are listed in the terminal, along with their status codes and error messages.
+
+1. If no dead links are found, Linkspector displays a success message, indicating that all links are working.
 
 ## What's planned
 - [x] Spinner for local runs.


### PR DESCRIPTION
Closes #8 

Focus points:
1. Use debian instead of alpine https://martinheinz.dev/blog/92
2. Run chrome without sandbox https://github.com/UmbrellaDocs/linkspector/discussions/11, since it is run as node user inside of the container. The tradeoff between sandboxing chrome vs giving more capabilities to the container could be reviewed later
3. Tested (using the docker command from README.md) on Ubuntu 20.04 x86_64 and MacOS M1 arm64 (aarch64 inside of the container)
4. bun ignored for now. ~~It would be nice if the build could be made more reproducible (`npm ci` instead of `npm install`), while limiting the number of extra dependencies (like bun), e.g. by using package-lock.json~~ (Done, subject to limitation https://github.com/npm/cli/issues/7224)
