### PR TITLE
Add space after url in error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ program
             spinner.stop();
             console.error(
               kleur.red(
-                `🚫 ${currentFile}, ${linkStatusObj.link}, ${linkStatusObj.status_code}, ${linkStatusObj.line_number}, ${linkStatusObj.error_message}`
+                `🚫 ${currentFile}, ${linkStatusObj.link} , ${linkStatusObj.status_code}, ${linkStatusObj.line_number}, ${linkStatusObj.error_message}`
               )
             );
             // Start the spinner again after printing an error message


### PR DESCRIPTION
Closes #31

Github will parse the trailing comma as part of the url when the warning appears in a github action log, so the link cannot be followed.

Arguably this is a github bug, and not a linkspector bug, because github does not include the comma in the URL in other places, like in issues.

Nevertheless, linkspector will probably be running in github actions quite often, so it would be good if the links are clickable from there without having to manually remove the comma.