### PR TITLE
Fix: Check section links in the same file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,9 @@ Thank you for considering contributing to Linkspector! We welcome contributions 
     - [Reporting Issues](#reporting-issues)
     - [Submitting Pull Requests](#submitting-pull-requests)
 4. [Development Setup](#development-setup)
-5. [Coding Guidelines](#coding-guidelines)
-6. [Testing](#testing)
-7. [Documentation](#documentation)
-8. [Commit Messages](#commit-messages)
-9. [License](#license)
+5. [Testing](#testing)
+6. [Commit Messages](#commit-messages)
+7. [License](#license)
 
 ## Getting Started
 
@@ -49,6 +47,14 @@ Our maintainers will review your PR as soon as possible and provide feedback if 
 ## Development Setup
 
 To set up a development environment, follow the instructions in the [Development Setup](DEV_SETUP.md) document. This will guide you through the process of installing dependencies and configuring your development environment.
+
+## Testing
+
+Before submitting a pull request, make sure to run the test suite to ensure that your changes do not introduce any regressions. To run the tests, use the following command:
+
+```bash
+npm test
+```
 
 ## Commit Messages
 

--- a/lib/check-file-links.js
+++ b/lib/check-file-links.js
@@ -12,6 +12,12 @@ function checkFileExistence(link, file) {
     let fileDir = path.dirname(file);
     let [urlWithoutSection, sectionId] = link.url.split("#");
     let filePath = path.resolve(fileDir, urlWithoutSection);
+
+    if (link.url.startsWith("#")) {
+      sectionId = link.url.slice(1);
+      filePath = file;
+    }
+
     if (fs.existsSync(filePath)) {
       statusCode = "200";
       status = "alive";
@@ -19,37 +25,32 @@ function checkFileExistence(link, file) {
         let mdContent = fs.readFileSync(filePath, "utf8");
         const tree = unified().use(remarkParse).use(remarkGfm).parse(mdContent);
 
-        let headingNodes = [];
+        let headingNodes = new Set();
         visit(tree, "heading", (node) => {
           let headingId;
-          // Check if the first child is an HTML node
           if (node.children[0].type === "html") {
-            // If it is, extract the id from it
             let match = node.children[0].value.match(/name="(.+?)"/);
             if (match) {
               headingId = match[1];
             }
           } else {
-            // If it's not, generate the id from the heading text
             let headingText = node.children[0].value;
-            // Check if the heading text contains a custom id
-            let match = headingText.match(/{#(.+?)}/);
-            if (match) {
-              // If it does, use the custom id
-              headingId = match[1];
+            if (headingText.includes("{#")) {
+              let match = headingText.match(/{#(.+?)}/);
+              if (match) {
+                headingId = match[1];
+              }
             } else {
-              // If it doesn't, generate the id from the heading text
               headingId = headingText
                 .toLowerCase()
                 .replace(/ /g, "-")
                 .replace(/\./g, "");
             }
           }
-          headingNodes.push(headingId);
+          headingNodes.add(headingId);
         });
 
-        // Check if sectionId exists in headingNodes
-        if (!headingNodes.includes(sectionId)) {
+        if (!headingNodes.has(sectionId)) {
           statusCode = "404";
           status = "error";
           errorMessage = `Cannot find section: ${sectionId} in file: ${link.url}.`;

--- a/lib/get-unique-links.js
+++ b/lib/get-unique-links.js
@@ -11,7 +11,6 @@ function getUniqueLinks(astNodes) {
       (node.type === "link" || node.type === "definition" || node.type === "image") &&
       node.url &&
       !uniqueUrls.has(node.url) &&
-      !node.url.startsWith("#") &&
       !node.url.startsWith("mailto:")
     ) {
       uniqueUrls.add(node.url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",

--- a/test/fixtures/relative/relative1.md
+++ b/test/fixtures/relative/relative1.md
@@ -2,7 +2,7 @@
 
 This is a paragraph in the first file in a first level heading.
 
-[Link to Relative 2 Heading Level One](relative2.md#relative-2-heading-level-one)
+[Link to Relative 1 Heading Level Two](#relative-1-heading-level-two)
 
 ## Relative 1 Heading Level Two
 


### PR DESCRIPTION
Previously, linkspector didn't handle links that reference sections within the same document (those starting with `#`).
With the changes in this PR, linkspector now correctly handle these intra-document links.

Fixes #26 