### PR TITLE
Use GitHub slugger for converting ID to slug

### DIFF
--- a/lib/check-file-links.js
+++ b/lib/check-file-links.js
@@ -4,6 +4,7 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
+import GithubSlugger from 'github-slugger'
 
 /**
  * Checks if a file and a section within the file exist.
@@ -19,6 +20,7 @@ function checkFileExistence(link, file) {
   let errorMessage = "";
 
   try {
+    let slugger = new GithubSlugger()
     // Split the URL into the file part and the section part
     const [urlWithoutSection = "", sectionId = null] = link.url.split("#");
 
@@ -40,14 +42,14 @@ function checkFileExistence(link, file) {
       const tree = unified().use(remarkParse).use(remarkGfm).parse(mdContent);
 
       // Collect all heading IDs in the file
+      // Use GitHub slugger to generate the heading slug for comparison
       const headingNodes = new Set();
       visit(tree, "heading", (node) => {
         const headingId = node.children[0].type === "html"
           ? node.children[0].value.match(/name="(.+?)"/)?.[1]
           : node.children[0].value.includes("{#")
           ? node.children[0].value.match(/{#(.+?)}/)?.[1]
-          : node.children[0].value.toLowerCase().replace(/ /g, "-").replace(/\./g, "");
-
+          : slugger.slug(node.children[0].value);
         headingNodes.add(headingId);
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrelladocs/linkspector",
-      "version": "0.3.3",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0",
+        "github-slugger": "^2.0.0",
         "glob": "^10.3.12",
         "ignore": "^5.3.1",
         "joi": "^17.13.1",
@@ -1815,6 +1816,11 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/glob": {
       "version": "10.3.12",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/UmbrellaDocs/linkspector#readme",
   "dependencies": {
     "commander": "^12.0.0",
+    "github-slugger": "^2.0.0",
     "glob": "^10.3.12",
     "ignore": "^5.3.1",
     "joi": "^17.13.1",


### PR DESCRIPTION
## Description

Replaces the manual generation of slugs for checking section links. Uses https://github.com/Flet/github-slugger

Fixes #57 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

