### PR TITLE
patch: fixed a bug when using modifiedfilesonly with Reviewdog

### DIFF
--- a/linkspector.js
+++ b/linkspector.js
@@ -99,9 +99,13 @@ export async function* linkspector(configFile, cmd) {
 
     // If no modified files are in the list of files to check, exit with a message
     if (modifiedFilesToCheck.length === 0) {
-      console.log(
-        'Skipped link checking. Modified files are not specified in the configuration.'
-      )
+      if (cmd.json) {
+        console.log('{}')
+      } else {
+        console.log(
+          'Skipped link checking. Modified files are not specified in the configuration.'
+        )
+      }
       process.exit(0)
     }
 


### PR DESCRIPTION
## Description

Fixes a bug when using `modifiedFilesOnly` option with [action-linkspector](https://github.com/UmbrellaDocs/action-linkspector).

Fixes https://github.com/UmbrellaDocs/action-linkspector/issues/3

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
