### PR TITLE
Updated the code to fix incorrect usage

### DIFF
--- a/lib/extract-asciidoc-links.js
+++ b/lib/extract-asciidoc-links.js
@@ -143,7 +143,7 @@ function extractAsciiDocLinks(filePath, options) {
         const extractLink = line.match(/\[#[^\]]+\]/g)
         extractLink.forEach((link) => {
           const newAnchor = link.replace(/^\[#|]$/g, '')
-          const matchIndex = line.indexOf(extractLink[i]) // Get the index of the match
+          const matchIndex = line.indexOf(link) // Get the index of the match
           const startColumn = matchIndex + 2 // Add 2 to account for the [# characters
           const endColumn = startColumn + newAnchor.length
           const startPosition = {


### PR DESCRIPTION
## Description

Changed `line.indexOf(extractLink[i])` to `line.indexOf(link)`

Fixes #78

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
