### PR TITLE
fix: glob not working on windows

### DIFF
--- a/lib/prepare-file-list.js
+++ b/lib/prepare-file-list.js
@@ -116,7 +116,9 @@ function prepareFilesList(config) {
       // Check if the dir exists
       if (existsSync(directory)) {
         files.push(
-          ...glob.sync(path.join(directory, '**', `*.${fileExtensions[0]}`))
+          ...glob.sync(
+            path.posix.join(directory, '**', `*.${fileExtensions[0]}`)
+          )
         )
       } else {
         console.error(


### PR DESCRIPTION
## Description

Glob only works with posix paths.

Fixes #80 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Information

Include any additional information about the pull request here.
