### PR TITLE
Fix regex pattern for extracting AsciiDoc links to not add period to end

### DIFF
--- a/lib/extract-asciidoc-links.js
+++ b/lib/extract-asciidoc-links.js
@@ -37,7 +37,9 @@ function extractAsciiDocLinks(filePath, options) {
       // Extract external hyperlinks
       let match
       while ((match = urlRegex.exec(line)) !== null) {
-        const url = match[0].replace(/^link:/, '') // Remove 'link:' prefix if present
+        const url = match[0]
+          .replace(/^link:/, '') // Remove 'link:' prefix if present
+          .replace(/\.$/, '') // Remove trailing period if present
         const position = {
           start: {
             line: lineNumber,

--- a/lib/handle-links-modification.js
+++ b/lib/handle-links-modification.js
@@ -14,6 +14,12 @@ function doReplacements(nodes, opts = {}) {
 
   return nodes.filter((node) => {
     let { url } = node
+
+    // Remove trailing period from URL if it exists
+    if (url.endsWith('.')) {
+      url = url.slice(0, -1)
+    }
+
     // Skip link checking if it matches any ignore pattern
     if (
       ignorePatterns.some(({ pattern }) => {


### PR DESCRIPTION
## Description

Sometimes links extracted from markdown have random period at the end

fixes: https://github.com/UmbrellaDocs/linkspector/issues/96

```
  message:"Cannot reach https://www.pharmacists.ca/cpha-ca/assets/File/minorailments/GERD_En_FINAL.pdf. Status: 403"  location:{path:"docs/resources/ailment_resources_links.md"  range:{start:{line:161  column:3}  end:{line:161  column:96}}}  severity:ERROR  source:{name:"linkspector"  url:"https://github.com/UmbrellaDocs/linkspector"}
  ```

Fixes # (issue number)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

Include any additional information about the pull request here.
