### PR TITLE
Check HTML anchor tags with id as well

### DIFF
--- a/lib/check-file-links.js
+++ b/lib/check-file-links.js
@@ -64,9 +64,12 @@ function checkFileExistence(link, file) {
                 : slugger.slug(headingText)
           headingNodes.add(headingId)
         } else if (node.type === 'html') {
-          const anchorNameMatch = node.value.match(/<a\s+.*?name="(.+?)".*?>/)
+          // Match both name and id attributes in HTML anchors
+          const anchorNameMatch = node.value.match(
+            /<a\s+.*?(name|id)="(.+?)".*?>/
+          )
           if (anchorNameMatch) {
-            const anchorName = anchorNameMatch[1]
+            const anchorName = anchorNameMatch[2]
             headingNodes.add(anchorName)
           }
         }

--- a/test/fixtures/markdown/with-html-anchors-id/.withHtmlAnchorsIdTest.yml
+++ b/test/fixtures/markdown/with-html-anchors-id/.withHtmlAnchorsIdTest.yml
@@ -1,0 +1,2 @@
+dirs:
+  - ./test/fixtures/markdown/with-html-anchors-id

--- a/test/fixtures/markdown/with-html-anchors-id/html-anchor-id.md
+++ b/test/fixtures/markdown/with-html-anchors-id/html-anchor-id.md
@@ -1,0 +1,9 @@
+# This is heading 1
+
+This is a paragraph in the first file in a first level heading.
+
+Anchor with `id` <a id="custom-id-with-id"></a>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vel mauris sit amet ipsum venenatis placerat.
+
+Link to anchor with `id` [Link to custom id with id](#custom-id-with-id).

--- a/test/fixtures/markdown/with-html-anchors-id/markdown-with-html-anchors-id.test.js
+++ b/test/fixtures/markdown/with-html-anchors-id/markdown-with-html-anchors-id.test.js
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+import { linkspector } from './linkspector.js'
+
+let cmd = {
+  json: true,
+}
+
+test('linkspector should check HTML encoded section links using ID attribute', async () => {
+  let hasErrorLinks = false
+  let currentFile = '' // Variable to store the current file name
+  let results = [] // Array to store the results if json is true
+
+  for await (const { file, result } of linkspector(
+    './test/fixtures/markdown/with-html-anchors-id/.withHtmlAnchorsIdTest.yml',
+    cmd
+  )) {
+    currentFile = file
+    for (const linkStatusObj of result) {
+      if (cmd.json) {
+        results.push({
+          file: currentFile,
+          link: linkStatusObj.link,
+          status_code: linkStatusObj.status_code,
+          line_number: linkStatusObj.line_number,
+          position: linkStatusObj.position,
+          status: linkStatusObj.status,
+          error_message: linkStatusObj.error_message,
+        })
+      }
+      if (linkStatusObj.status === 'error') {
+        hasErrorLinks = true
+      }
+    }
+  }
+
+  // Test expectations for link checks
+  expect(hasErrorLinks).toBe(false)
+  expect(results.length).toBe(1)
+  expect(results[0].status).toBe('alive')
+})


### PR DESCRIPTION
## Description

Previously, Linkspector would only check for HTMl anchors defined with `name`. Ideally, it should check both `id` and `name` values.

Fixes #103

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
