### PR TITLE
Feat: Add support for HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Linkspector is a powerful tool for anyone who creates content using markup langu
 1. **Enhanced Link Checking with Puppeteer**: It uses [Puppeteer](https://pptr.dev/) to check links in Chrome's headless mode, reducing the number of false positives.
 2. **Addresses limitations and adds user-requested features**: It is built to adress the shortcomings in [GitHub Action - Markdown link check](https://github.com/gaurav-nelson/github-action-markdown-link-check) and adds many user requested features.
 3. **Single repository for seamless collaboration**: All the code it needs to run is in a single repository, making it easier for community to collaborate.
-4. **Focused for CI/CD use**: Linkspector is purposefully tailored to run into your CI/CD pipelines. This ensures that link checking becomes an integral part of your development workflow.
+4. **Focused for CI/CD use**: Linkspector ([action-linkspector](https://github.com/UmbrellaDocs/action-linkspector)) is purposefully tailored to run into your CI/CD pipelines. This ensures that link checking becomes an integral part of your development workflow.
 
 ## Installation
 
@@ -112,6 +112,7 @@ Following are the available configuration options:
 | [`aliveStatusCodes`](#alive-status-codes)         | The list of HTTP status codes that are considered as "alive" links.                                   | No                                |
 | [`useGitIgnore`](#use-gitignore)                  | Indicates whether to use the rules defined in the `.gitignore` file to exclude files and directories. | No                                |
 | [`modifiedFilesOnly`](#check-modified-files-only) | Indicates whether to check only the files that have been modified in the last git commit.             | No                                |
+| [`httpHeaders`](#http-headers)                    | The list of URLs and their corresponding HTTP headers to be used during link checking.                | No                                |
 
 ### Files to Check
 
@@ -225,6 +226,31 @@ When enabled, Linkspector will use `git` to find the list of modified files and 
 
 Also, if no modified files are found in the list of files to check, Linkspector will skip link checking and exit with a message indicating that no modified files have been edited so it will skip checking.
 
+### HTTP headers
+
+The `httpHeaders` option allows you to specify HTTP headers for specific URLs that require authorization. You can use environment variables for secure values.
+
+1. Create a `.env` file in the root directory of your project and add the environment variables. For example:
+
+   ```env
+   AUTH_TOKEN=abcdef123456
+   ```
+
+1. Add the `httpHeaders` section to the configuration file and specify the URLs and headers. For example:
+
+   ```yaml
+   httpHeaders:
+     - url:
+         - https://example1.com
+       headers:
+         Foo: Bar
+     - url:
+         - https://example2.com
+       headers:
+         Authorization: ${AUTH_TOKEN}
+         Foo: Bar
+   ```
+
 ### Sample configuration
 
 ```yml
@@ -250,6 +276,12 @@ replacementPatterns:
     replacement: '$1/id/$3'
   - pattern: "\\[([^\\]]+)\\]\\((https?://example.com)/file\\)"
     replacement: '<a href="$2/file">$1</a>'
+httpHeaders:
+  - url:
+      - https://example1.com
+    headers:
+      Authorization: Basic Zm9vOmJhcg==
+      Foo: Bar
 aliveStatusCodes:
   - 200
   - 201
@@ -303,20 +335,6 @@ To use Linkspector with Docker, follow these steps:
           --name linkspector umbrelladocs/linkspector \
           bash -c 'linkspector check -c /path/to/custom-config.yml'
    ```
-
-## What's planned
-
-- [x] Spinner for local runs.
-- [x] Create a GitHub action. See [action-linkspector](https://github.com/UmbrellaDocs/action-linkspector)
-- [x] Modified files only check.
-- [!] Asciidoc support. (Limited to hyperlinks only)
-- [ ] ReStructured Text support.
-- [ ] Disable binary files downlaod.
-- [x] JSON output for `failed-only` ~~or `all`~~ links.
-- ~~[ ] CSV output for `all` links.~~ (dropped for now)
-- ~~[ ] Experimaental mode to gather all links and check them in batches to study performance gains.~~ (dropped for now)
-- ~~[ ] Proxy support to connect puppeteer to a remote service.~~ (dropped for now)
-- ~~[ ] Puppeteer config support.~~ (dropped for now)
 
 ## Contributing
 

--- a/index.test.js
+++ b/index.test.js
@@ -34,7 +34,7 @@ test('linkspector should check top-level relative links in Markdown file', async
   }
 
   expect(hasErrorLinks).toBe(false)
-  expect(results.length).toBe(21)
+  expect(results.length).toBe(22)
 })
 
 test('linkspector should track statistics correctly when stats option is enabled', async () => {
@@ -87,7 +87,7 @@ test('linkspector should track statistics correctly when stats option is enabled
 
   // Verify statistics are being tracked correctly
   expect(stats.filesChecked).toBeGreaterThan(0)
-  expect(stats.totalLinks).toBe(21)
+  expect(stats.totalLinks).toBe(22)
   expect(stats.totalLinks).toBe(
     stats.httpLinks +
       stats.fileLinks +

--- a/lib/batch-check-links.js
+++ b/lib/batch-check-links.js
@@ -22,14 +22,22 @@ function createLinkStatus(link, status, statusCode, errorMessage = null) {
   }
 }
 
-async function processLink(link, page, aliveStatusCodes) {
+async function processLink(link, page, aliveStatusCodes, httpHeaders) {
   let status = null
   let statusCode = null
   let errorMessage = null
 
   try {
     if (isUrl(link.url)) {
-      const response = await page.goto(link.url, { waitUntil: 'load' })
+      const headers =
+        httpHeaders.find((header) =>
+          header.url.some((urlPattern) => link.url.includes(urlPattern))
+        )?.headers || {}
+
+      const response = await page.goto(link.url, {
+        waitUntil: 'load',
+        headers,
+      })
       statusCode = response.status()
       if (aliveStatusCodes && aliveStatusCodes.includes(statusCode)) {
         status = 'assumed alive'
@@ -46,7 +54,12 @@ async function processLink(link, page, aliveStatusCodes) {
 }
 
 async function checkHyperlinks(nodes, options = {}, filePath) {
-  const { batchSize = 100, retryCount = 3, aliveStatusCodes } = options
+  const {
+    batchSize = 100,
+    retryCount = 3,
+    aliveStatusCodes,
+    httpHeaders = [],
+  } = options
   const linkStatusList = []
   const tempArray = []
 
@@ -150,7 +163,12 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
 
         while (retryCountLocal < retryCount) {
           try {
-            linkStatus = await processLink(link, page, aliveStatusCodes)
+            linkStatus = await processLink(
+              link,
+              page,
+              aliveStatusCodes,
+              httpHeaders
+            )
             break
           } catch (error) {
             retryCountLocal++

--- a/lib/handle-links-modification.js
+++ b/lib/handle-links-modification.js
@@ -9,6 +9,8 @@
  *
  * @returns {Array} The modified nodes.
  */
+import { escapeRegExp } from 'lodash-es'
+
 function doReplacements(nodes, opts = {}) {
   const { ignorePatterns = [], replacementPatterns = [], baseUrl } = opts
 
@@ -17,7 +19,9 @@ function doReplacements(nodes, opts = {}) {
     // Skip link checking if it matches any ignore pattern
     if (
       ignorePatterns.some(({ pattern }) => {
-        const regex = new RegExp(pattern)
+        // Sanitize the pattern before creating the RegExp
+        const sanitizedPattern = escapeRegExp(pattern)
+        const regex = new RegExp(sanitizedPattern)
         return regex.test(url)
       })
     ) {
@@ -31,7 +35,9 @@ function doReplacements(nodes, opts = {}) {
 
     // Replace link URL based on replacement patterns
     replacementPatterns.forEach(({ pattern, replacement }) => {
-      url = url.replace(new RegExp(pattern), replacement)
+      // Sanitize the pattern before creating the RegExp
+      const sanitizedPattern = escapeRegExp(pattern)
+      url = url.replace(new RegExp(sanitizedPattern), replacement)
     })
     node.url = url
 

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -23,15 +23,12 @@ async function validateConfig(config) {
       excludedDirs: Joi.array().items(Joi.string()),
       fileExtensions: Joi.array().items(Joi.string()),
       baseUrl: Joi.string(),
-      httpHeaders: Joi.object({
-        url: Joi.string(),
-        headers: Joi.array().items(
-          Joi.object({
-            name: Joi.string().required(),
-            value: Joi.string().required(),
-          })
-        ),
-      }),
+      httpHeaders: Joi.array().items(
+        Joi.object({
+          url: Joi.array().items(Joi.string().uri()).required(),
+          headers: Joi.object().pattern(Joi.string(), Joi.string()).required(),
+        })
+      ),
       aliveStatusCodes: Joi.array().items(Joi.number()),
       ignorePatterns: Joi.array().items(
         Joi.object({

--- a/linkspector.js
+++ b/linkspector.js
@@ -2,6 +2,7 @@ import { execSync } from 'child_process'
 import { readFileSync } from 'fs'
 import path from 'path'
 import yaml from 'js-yaml'
+import dotenv from 'dotenv'
 import { validateConfig } from './lib/validate-config.js'
 import { prepareFilesList } from './lib/prepare-file-list.js'
 import { extractMarkdownHyperlinks } from './lib/extract-markdown-hyperlinks.js'
@@ -9,6 +10,19 @@ import { extractAsciiDocLinks } from './lib/extract-asciidoc-links.js'
 import { getUniqueLinks } from './lib/get-unique-links.js'
 import { checkHyperlinks } from './lib/batch-check-links.js'
 import { updateLinkStatusObj } from './lib/update-linkstatus-obj.js'
+
+// Load environment variables from .env file
+dotenv.config()
+
+// Function to replace placeholders with environment variables
+function replaceEnvVariables(config) {
+  const configString = JSON.stringify(config)
+  const replacedConfigString = configString.replace(
+    /\$\{(\w+)\}/g,
+    (_, name) => process.env[name] || ''
+  )
+  return JSON.parse(replacedConfigString)
+}
 
 // Function to check if git is installed
 function isGitInstalled() {
@@ -43,6 +57,9 @@ export async function* linkspector(configFile, cmd) {
     if (config === null || Object.keys(config).length === 0) {
       throw new Error('Failed to parse the YAML content.')
     }
+
+    // Replace environment variables in the configuration
+    config = replaceEnvVariables(config)
 
     try {
       const isValid = await validateConfig(config)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrelladocs/linkspector",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",
+        "dotenv": "^16.4.7",
         "github-slugger": "^2.0.0",
         "glob": "^11.0.1",
         "ignore": "^7.0.3",
@@ -1582,6 +1583,18 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
       "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.14",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrelladocs/linkspector",
-      "version": "0.3.14",
+      "version": "0.3.13",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",
@@ -17,6 +17,7 @@
         "joi": "^17.13.3",
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
+        "lodash-es": "^4.17.21",
         "ora": "^8.2.0",
         "puppeteer": "^24.4.0",
         "remark-gfm": "^4.0.1",
@@ -2114,6 +2115,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",
@@ -53,7 +53,8 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "dotenv": "^16.4.7"
   },
   "devDependencies": {
     "vitest": "^3.0.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.3.14",
+  "version": "0.3.13",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",
@@ -42,19 +42,20 @@
   "homepage": "https://github.com/UmbrellaDocs/linkspector#readme",
   "dependencies": {
     "commander": "^13.1.0",
+    "dotenv": "^16.4.7",
     "github-slugger": "^2.0.0",
     "glob": "^11.0.1",
     "ignore": "^7.0.3",
     "joi": "^17.13.3",
     "js-yaml": "^4.1.0",
     "kleur": "^4.1.5",
+    "lodash-es": "^4.17.21",
     "ora": "^8.2.0",
     "puppeteer": "^24.4.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.0.0",
-    "dotenv": "^16.4.7"
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "vitest": "^3.0.9"

--- a/test/fixtures/headers.test.js
+++ b/test/fixtures/headers.test.js
@@ -1,0 +1,153 @@
+import { expect, test, vi, beforeEach } from 'vitest'
+import { checkHyperlinks } from '../../lib/batch-check-links.js'
+
+// Add the environment variable substitution function that matches what's in linkspector.js
+function replaceEnvVariables(obj) {
+  const objString = JSON.stringify(obj)
+  const replacedObjString = objString.replace(
+    /\$\{(\w+)\}/g,
+    (_, name) => process.env[name] || ''
+  )
+  return JSON.parse(replacedObjString)
+}
+
+// Mock puppeteer
+vi.mock('puppeteer', () => {
+  return {
+    default: {
+      launch: vi.fn().mockImplementation(() => {
+        return {
+          newPage: vi.fn().mockImplementation(() => {
+            return {
+              setUserAgent: vi.fn(),
+              setRequestInterception: vi.fn(),
+              on: vi.fn(),
+              goto: vi.fn().mockImplementation((url, options) => {
+                // Track which headers were passed
+                capturedHeaders = options.headers || {}
+
+                return {
+                  status: vi.fn().mockReturnValue(200),
+                  ok: vi.fn().mockReturnValue(true),
+                }
+              }),
+              close: vi.fn(),
+            }
+          }),
+          close: vi.fn(),
+        }
+      }),
+    },
+  }
+})
+
+// Variable to capture headers passed to page.goto
+let capturedHeaders = {}
+
+beforeEach(() => {
+  // Reset captured headers before each test
+  capturedHeaders = {}
+
+  // Reset mocks
+  vi.clearAllMocks()
+})
+
+test('applies correct HTTP headers based on URL patterns', async () => {
+  // Prepare test data
+  const nodes = [
+    {
+      type: 'link',
+      url: 'https://example1.com/test',
+      position: { start: { line: 1, column: 1 }, end: { line: 1, column: 30 } },
+    },
+  ]
+
+  const httpHeaders = [
+    {
+      url: ['https://example1.com'],
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-Custom-Header': 'CustomValue',
+      },
+    },
+  ]
+
+  // Run the function
+  await checkHyperlinks(nodes, { httpHeaders }, '/path/to/file')
+
+  // Verify the correct headers were applied
+  expect(capturedHeaders).toEqual({
+    Authorization: 'Bearer token123',
+    'X-Custom-Header': 'CustomValue',
+  })
+})
+
+test('applies no headers when URL does not match patterns', async () => {
+  // Prepare test data
+  const nodes = [
+    {
+      type: 'link',
+      url: 'https://different-domain.com/test',
+      position: { start: { line: 1, column: 1 }, end: { line: 1, column: 30 } },
+    },
+  ]
+
+  const httpHeaders = [
+    {
+      url: ['https://example1.com', 'https://example2.com'],
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-Custom-Header': 'CustomValue',
+      },
+    },
+  ]
+
+  // Run the function
+  await checkHyperlinks(nodes, { httpHeaders }, '/path/to/file')
+
+  // Verify no headers were applied for non-matching URL
+  expect(capturedHeaders).toEqual({})
+})
+
+test('supports environment variable substitution in headers', async () => {
+  // Mock process.env
+  const originalEnv = process.env
+  process.env = {
+    ...originalEnv,
+    AUTH_TOKEN: 'supersecrettoken',
+  }
+
+  // Prepare test data
+  const nodes = [
+    {
+      type: 'link',
+      url: 'https://example3.com/api',
+      position: { start: { line: 1, column: 1 }, end: { line: 1, column: 30 } },
+    },
+  ]
+
+  let httpHeaders = [
+    {
+      url: ['https://example3.com'],
+      headers: {
+        Authorization: 'Bearer ${AUTH_TOKEN}',
+        'X-API-Key': 'fixed-value',
+      },
+    },
+  ]
+
+  // Process environment variables in headers similar to what linkspector.js does
+  httpHeaders = replaceEnvVariables(httpHeaders)
+
+  // Run the function
+  await checkHyperlinks(nodes, { httpHeaders }, '/path/to/file')
+
+  // Verify the headers with environment variable substitution
+  expect(capturedHeaders).toEqual({
+    Authorization: 'Bearer supersecrettoken',
+    'X-API-Key': 'fixed-value',
+  })
+
+  // Restore original env
+  process.env = originalEnv
+})


### PR DESCRIPTION
## Description

Adds support for setting custom headers and using `.env` for secrets.

Fixes #92 

## Type of Change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
