### PR TITLE
feat: Make config.fileExtensions config work with confg.dirs.

### DIFF
--- a/lib/prepare-file-list.js
+++ b/lib/prepare-file-list.js
@@ -115,9 +115,13 @@ function prepareFilesList(config) {
 
       // Check if the dir exists
       if (existsSync(directory)) {
+        let fileExtensionsGlob =
+          fileExtensions.length > 1
+            ? `{${fileExtensions.join(',')}}`
+            : fileExtensions[0]
         files.push(
           ...glob.sync(
-            path.posix.join(directory, '**', `*.${fileExtensions[0]}`)
+            path.posix.join(directory, '**', `*.${fileExtensionsGlob}`)
           )
         )
       } else {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+// vitest.config.js
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // the global timeout in milliseconds 10 seconds
+    testTimeout: 10000,
+  },
+})


### PR DESCRIPTION
## Description

Ensures `config.fileExtensions` works as expected when combined with `config.dirs` entries for discovering files to check.

Surprisingly, at present only the [first entry](https://github.com/UmbrellaDocs/linkspector/blob/main/lib/prepare-file-list.js#L120) in the `config.fileExtensions` list is used to build globs to discover relevant files to check in the specified directories. This PR includes all entries in `config.fileExtensions` in the glob string to make sure all relevant files are discovered in each of the directories included in `config.dirs`.

For example, consider the following config:
```yaml
dirs:
  - foo
fileExtensions:
  - bar
  - baz
```

Currently, Linkspector would only test files matching the glob `foo/**/*.bar`.

This PR changes the glob to `foo/**/*.{bar,baz}` ensuring all intended files are discovered and tested.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

Include any additional information about the pull request here.
