### PR TITLE
feat: add followRedirects option for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Following are the available configuration options:
 | [`useGitIgnore`](#use-gitignore)                  | Indicates whether to use the rules defined in the `.gitignore` file to exclude files and directories. | No                                |
 | [`modifiedFilesOnly`](#check-modified-files-only) | Indicates whether to check only the files that have been modified in the last git commit.             | No                                |
 | [`httpHeaders`](#http-headers)                    | The list of URLs and their corresponding HTTP headers to be used during link checking.                | No                                |
+| [`followRedirects`](#follow-redirects)            | Controls how HTTP redirects (e.g., 301, 302) are handled.                                           | No                                |
 
 ### Files to Check
 
@@ -251,6 +252,29 @@ The `httpHeaders` option allows you to specify HTTP headers for specific URLs th
          Foo: Bar
    ```
 
+### Follow Redirects
+
+The `followRedirects` option controls how Linkspector handles HTTP redirects (e.g., status codes 301, 302).
+
+-   **Type:** `boolean`
+-   **Default:** `true`
+
+**Behavior:**
+
+-   When `followRedirects: true` (default):
+    Linkspector will follow HTTP redirects to their final destination. The status of the link will be determined by the status code of this final destination. For example, if `http://example.com/old` redirects to `http://example.com/new` and `/new` returns a 200 OK, the original link `/old` will be reported as 'alive' (200), with a message indicating it was redirected.
+
+-   When `followRedirects: false`:
+    Linkspector will *not* follow HTTP redirects. If a link returns a redirect status code (e.g., 301, 302, 307, 308), it will be reported as an 'error'. The reported status code will be the original redirect status code (e.g., 301), and the error message will indicate that the link redirected but `followRedirects` was set to `false`.
+
+**Example:**
+
+To disable following redirects:
+
+```yaml
+followRedirects: false
+```
+
 ### Sample configuration
 
 ```yml
@@ -287,6 +311,7 @@ aliveStatusCodes:
   - 201
   - 204
 useGitIgnore: true
+followRedirects: false # Example of including it in a full config
 ```
 
 ## Sample output

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Following are the available configuration options:
 | [`useGitIgnore`](#use-gitignore)                  | Indicates whether to use the rules defined in the `.gitignore` file to exclude files and directories. | No                                |
 | [`modifiedFilesOnly`](#check-modified-files-only) | Indicates whether to check only the files that have been modified in the last git commit.             | No                                |
 | [`httpHeaders`](#http-headers)                    | The list of URLs and their corresponding HTTP headers to be used during link checking.                | No                                |
-| [`followRedirects`](#follow-redirects)            | Controls how HTTP redirects (e.g., 301, 302) are handled.                                           | No                                |
+| [`followRedirects`](#follow-redirects)            | Controls how HTTP redirects (e.g., 301, 302) are handled.                                             | No                                |
 
 ### Files to Check
 
@@ -256,16 +256,16 @@ The `httpHeaders` option allows you to specify HTTP headers for specific URLs th
 
 The `followRedirects` option controls how Linkspector handles HTTP redirects (e.g., status codes 301, 302).
 
--   **Type:** `boolean`
--   **Default:** `true`
+- **Type:** `boolean`
+- **Default:** `true`
 
 **Behavior:**
 
--   When `followRedirects: true` (default):
-    Linkspector will follow HTTP redirects to their final destination. The status of the link will be determined by the status code of this final destination. For example, if `http://example.com/old` redirects to `http://example.com/new` and `/new` returns a 200 OK, the original link `/old` will be reported as 'alive' (200), with a message indicating it was redirected.
+- When `followRedirects: true` (default):
+  Linkspector will follow HTTP redirects to their final destination. The status of the link will be determined by the status code of this final destination. For example, if `http://example.com/old` redirects to `http://example.com/new` and `/new` returns a 200 OK, the original link `/old` will be reported as 'alive' (200), with a message indicating it was redirected.
 
--   When `followRedirects: false`:
-    Linkspector will *not* follow HTTP redirects. If a link returns a redirect status code (e.g., 301, 302, 307, 308), it will be reported as an 'error'. The reported status code will be the original redirect status code (e.g., 301), and the error message will indicate that the link redirected but `followRedirects` was set to `false`.
+- When `followRedirects: false`:
+  Linkspector will _not_ follow HTTP redirects. If a link returns a redirect status code (e.g., 301, 302, 307, 308), it will be reported as an 'error'. The reported status code will be the original redirect status code (e.g., 301), and the error message will indicate that the link redirected but `followRedirects` was set to `false`.
 
 **Example:**
 

--- a/index.test.js
+++ b/index.test.js
@@ -34,7 +34,7 @@ test('linkspector should check top-level relative links in Markdown file', async
   }
 
   expect(hasErrorLinks).toBe(false)
-  expect(results.length).toBe(22)
+  expect(results.length).toBe(23)
 })
 
 test('linkspector should track statistics correctly when stats option is enabled', async () => {
@@ -87,7 +87,7 @@ test('linkspector should track statistics correctly when stats option is enabled
 
   // Verify statistics are being tracked correctly
   expect(stats.filesChecked).toBeGreaterThan(0)
-  expect(stats.totalLinks).toBe(22)
+  expect(stats.totalLinks).toBe(23)
   expect(stats.totalLinks).toBe(
     stats.httpLinks +
       stats.fileLinks +

--- a/lib/batch-check-links.js
+++ b/lib/batch-check-links.js
@@ -22,7 +22,7 @@ function createLinkStatus(link, status, statusCode, errorMessage = null) {
   }
 }
 
-async function processLink(link, page, aliveStatusCodes, httpHeaders) {
+async function processLink(link, page, aliveStatusCodes, httpHeaders, followRedirects) {
   let status = null
   let statusCode = null
   let errorMessage = null
@@ -35,11 +35,20 @@ async function processLink(link, page, aliveStatusCodes, httpHeaders) {
         )?.headers || {}
 
       const response = await page.goto(link.url, {
-        waitUntil: 'load',
+        waitUntil: 'load', // Puppeteer follows redirects by default.
         headers,
       })
       statusCode = response.status()
-      if (aliveStatusCodes && aliveStatusCodes.includes(statusCode)) {
+      const redirectChain = response.request().redirectChain()
+
+      if (!followRedirects && redirectChain.length > 0) {
+        // If followRedirects is false and there was a redirect
+        status = 'error'
+        const originalStatusCode = redirectChain[0].response().status()
+        errorMessage = `Link redirected (from ${redirectChain[0].url()} status: ${originalStatusCode} to ${response.url()}), but followRedirects is set to false.`
+        // We might want to use the original redirect status code if available and makes sense
+        statusCode = originalStatusCode !== 0 ? originalStatusCode : statusCode; 
+      } else if (aliveStatusCodes && aliveStatusCodes.includes(statusCode)) {
         status = 'assumed alive'
       } else {
         status = response.ok() ? 'alive' : 'error'
@@ -59,6 +68,7 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
     retryCount = 3,
     aliveStatusCodes,
     httpHeaders = [],
+    followRedirects = true, // Default to true if not provided
   } = options
   const linkStatusList = []
   const tempArray = []
@@ -74,16 +84,30 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
   for (let link of filteredNodes) {
     try {
       if (isUrl(link.url)) {
-        const response = await fetch(link.url, {
+        const fetchOptions = {
           method: 'HEAD',
-          redirect: 'follow',
-        })
-        let message = response.redirected
-          ? `redirected to ${response.url}`
-          : null
+          redirect: followRedirects ? 'follow' : 'manual',
+        }
+        const response = await fetch(link.url, fetchOptions)
         const statusCode = response.status
+        let message = null
+
+        // Handle manual redirect: if followRedirects is false and a redirect occurs
+        if (!followRedirects && (response.type === 'opaqueredirect' || [301, 302, 307, 308].includes(statusCode))) {
+          const redirectedTo = response.headers.get('location')
+          const errorMessage = `Link redirected${redirectedTo ? ' to ' + redirectedTo : ''}, but followRedirects is set to false.`
+          const linkStatus = createLinkStatus(
+            link,
+            'error',
+            statusCode === 0 && response.type === 'opaqueredirect' ? 302 : statusCode, // Use 302 for opaque, else actual
+            errorMessage
+          )
+          linkStatusList.push(linkStatus)
+          continue
+        }
 
         if (response.ok) {
+          message = response.redirected ? `redirected to ${response.url}` : null
           const linkStatus = createLinkStatus(
             link,
             'alive',
@@ -97,6 +121,7 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
           linkStatusList.push(linkStatus)
           continue
         } else {
+          // If not ok, and not an explicit redirect handled above, or not in aliveStatusCodes
           tempArray.push(link)
         }
       } else {
@@ -167,7 +192,8 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
               link,
               page,
               aliveStatusCodes,
-              httpHeaders
+              httpHeaders,
+              followRedirects // Pass followRedirects here
             )
             break
           } catch (error) {

--- a/lib/batch-check-links.js
+++ b/lib/batch-check-links.js
@@ -22,7 +22,13 @@ function createLinkStatus(link, status, statusCode, errorMessage = null) {
   }
 }
 
-async function processLink(link, page, aliveStatusCodes, httpHeaders, followRedirects) {
+async function processLink(
+  link,
+  page,
+  aliveStatusCodes,
+  httpHeaders,
+  followRedirects
+) {
   let status = null
   let statusCode = null
   let errorMessage = null
@@ -47,7 +53,7 @@ async function processLink(link, page, aliveStatusCodes, httpHeaders, followRedi
         const originalStatusCode = redirectChain[0].response().status()
         errorMessage = `Link redirected (from ${redirectChain[0].url()} status: ${originalStatusCode} to ${response.url()}), but followRedirects is set to false.`
         // We might want to use the original redirect status code if available and makes sense
-        statusCode = originalStatusCode !== 0 ? originalStatusCode : statusCode; 
+        statusCode = originalStatusCode !== 0 ? originalStatusCode : statusCode
       } else if (aliveStatusCodes && aliveStatusCodes.includes(statusCode)) {
         status = 'assumed alive'
       } else {
@@ -93,13 +99,19 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
         let message = null
 
         // Handle manual redirect: if followRedirects is false and a redirect occurs
-        if (!followRedirects && (response.type === 'opaqueredirect' || [301, 302, 307, 308].includes(statusCode))) {
+        if (
+          !followRedirects &&
+          (response.type === 'opaqueredirect' ||
+            [301, 302, 307, 308].includes(statusCode))
+        ) {
           const redirectedTo = response.headers.get('location')
           const errorMessage = `Link redirected${redirectedTo ? ' to ' + redirectedTo : ''}, but followRedirects is set to false.`
           const linkStatus = createLinkStatus(
             link,
             'error',
-            statusCode === 0 && response.type === 'opaqueredirect' ? 302 : statusCode, // Use 302 for opaque, else actual
+            statusCode === 0 && response.type === 'opaqueredirect'
+              ? 302
+              : statusCode, // Use 302 for opaque, else actual
             errorMessage
           )
           linkStatusList.push(linkStatus)

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -46,6 +46,7 @@ async function validateConfig(config) {
       //showErrorsOnly: Joi.boolean(),
       useGitIgnore: Joi.boolean(),
       modifiedFilesOnly: Joi.boolean(),
+      followRedirects: Joi.boolean().default(true),
     }).or('files', 'dirs')
 
     // Validate the config against the schema

--- a/test/fixtures/redirects/config-redirects-false.yml
+++ b/test/fixtures/redirects/config-redirects-false.yml
@@ -1,0 +1,3 @@
+files:
+  - test/fixtures/redirects/redirects.md
+followRedirects: false

--- a/test/fixtures/redirects/config-redirects-true.yml
+++ b/test/fixtures/redirects/config-redirects-true.yml
@@ -1,0 +1,4 @@
+files:
+  - test/fixtures/redirects/redirects.md
+# followRedirects is true by default, so we can omit it or set it explicitly.
+# For clarity in testing, we can omit it to test the default behavior.

--- a/test/fixtures/redirects/redirects.md
+++ b/test/fixtures/redirects/redirects.md
@@ -1,0 +1,20 @@
+# Redirect Test Links
+
+This file contains links for testing the followRedirects feature.
+
+## Scenario 1 & 2: Redirecting Link
+[Permanent Redirect (301)](http://localhost:3000/redirect-permanent)
+[Temporary Redirect (302)](http://localhost:3000/redirect-temporary)
+
+## Scenario 3 & 4: Non-Redirecting Link
+[Direct OK (200)](http://localhost:3000/ok)
+
+## Scenario 5: Error Link
+[Not Found (404)](http://localhost:3000/not-found)
+
+## Scenario: Redirect to external allowed
+[External Redirect (301)](http://localhost:3000/redirect-external)
+[Final External Destination](https://example.com)
+
+## Scenario: Redirect loop
+[Redirect Loop](http://localhost:3000/redirect-loop1)

--- a/test/fixtures/redirects/redirects.md
+++ b/test/fixtures/redirects/redirects.md
@@ -3,18 +3,23 @@
 This file contains links for testing the followRedirects feature.
 
 ## Scenario 1 & 2: Redirecting Link
+
 [Permanent Redirect (301)](http://localhost:3000/redirect-permanent)
 [Temporary Redirect (302)](http://localhost:3000/redirect-temporary)
 
 ## Scenario 3 & 4: Non-Redirecting Link
+
 [Direct OK (200)](http://localhost:3000/ok)
 
 ## Scenario 5: Error Link
+
 [Not Found (404)](http://localhost:3000/not-found)
 
 ## Scenario: Redirect to external allowed
+
 [External Redirect (301)](http://localhost:3000/redirect-external)
 [Final External Destination](https://example.com)
 
 ## Scenario: Redirect loop
+
 [Redirect Loop](http://localhost:3000/redirect-loop1)

--- a/test/fixtures/redirects/redirects.test.js
+++ b/test/fixtures/redirects/redirects.test.js
@@ -9,7 +9,10 @@ const __dirname = path.dirname(__filename)
 
 const fixturesDir = path.join(__dirname)
 // const markdownFile = path.join(fixturesDir, 'redirects.md') // No longer directly passed
-const configFileFollowFalse = path.join(fixturesDir, 'config-redirects-false.yml')
+const configFileFollowFalse = path.join(
+  fixturesDir,
+  'config-redirects-false.yml'
+)
 const configFileFollowTrue = path.join(fixturesDir, 'config-redirects-true.yml')
 
 let server
@@ -39,8 +42,7 @@ const serverHandler = (req, res) => {
   } else if (req.url === '/redirect-loop2') {
     res.writeHead(302, { Location: `http://${HOST}:${PORT}/redirect-loop1` })
     res.end()
-  }
-  else {
+  } else {
     res.writeHead(404, { 'Content-Type': 'text/plain' })
     res.end('Not Found')
   }
@@ -63,7 +65,9 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`)
+    const redirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`
+    )
     expect(redirectLink.status).toBe('alive')
     expect(redirectLink.status_code).toBe(200) // Final destination
     expect(redirectLink.error_message).toContain('redirected to')
@@ -76,7 +80,9 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`)
+    const redirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`
+    )
     expect(redirectLink.status).toBe('alive')
     expect(redirectLink.status_code).toBe(200) // Final destination
     expect(redirectLink.error_message).toContain('redirected to')
@@ -89,10 +95,14 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`)
+    const redirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`
+    )
     expect(redirectLink.status).toBe('error')
     expect(redirectLink.status_code).toBe(301)
-    expect(redirectLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+    expect(redirectLink.error_message).toMatch(
+      /redirected.*followRedirects is set to false/i
+    )
   })
 
   // Scenario 2 (bis): followRedirects: false - Temporary Redirect (302)
@@ -102,10 +112,14 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`)
+    const redirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`
+    )
     expect(redirectLink.status).toBe('error')
     expect(redirectLink.status_code).toBe(302)
-    expect(redirectLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+    expect(redirectLink.error_message).toMatch(
+      /redirected.*followRedirects is set to false/i
+    )
   })
 
   // Scenario 3: Non-redirecting link with followRedirects: false
@@ -115,7 +129,9 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const okLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/ok`)
+    const okLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/ok`
+    )
     expect(okLink.status).toBe('alive')
     expect(okLink.status_code).toBe(200)
   })
@@ -127,7 +143,9 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const okLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/ok`)
+    const okLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/ok`
+    )
     expect(okLink.status).toBe('alive')
     expect(okLink.status_code).toBe(200)
   })
@@ -139,11 +157,13 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const notFoundLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/not-found`)
+    const notFoundLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/not-found`
+    )
     expect(notFoundLink.status).toBe('error')
     expect(notFoundLink.status_code).toBe(404)
   })
-  
+
   // Scenario: Link that results in an actual error (404) with followRedirects: true (default)
   it('should report a 404 link as error (404) when followRedirects is true (default)', async () => {
     const resultsAsync = linkspector(configFileFollowTrue, {})
@@ -151,7 +171,9 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const notFoundLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/not-found`)
+    const notFoundLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/not-found`
+    )
     expect(notFoundLink.status).toBe('error')
     expect(notFoundLink.status_code).toBe(404)
   })
@@ -163,13 +185,17 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const externalRedirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-external`)
+    const externalRedirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-external`
+    )
     expect(externalRedirectLink.status).toBe('alive')
     // Note: status code might be from the final destination (example.com) if HEAD request works,
     // or could be tricky if example.com blocks HEAD. Puppeteer fallback should handle it.
     // For now, checking for 'alive' is the primary goal.
     // expect(externalRedirectLink.status_code).toBe(200) // This can be flaky with external sites
-    expect(externalRedirectLink.error_message).toContain('redirected to https://example.com')
+    expect(externalRedirectLink.error_message).toContain(
+      'redirected to https://example.com'
+    )
   }, 10000) // Increased timeout
 
   // Scenario: External redirect disallowed when followRedirects is false
@@ -179,21 +205,29 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const externalRedirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-external`)
+    const externalRedirectLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-external`
+    )
     expect(externalRedirectLink.status).toBe('error')
     expect(externalRedirectLink.status_code).toBe(301)
-    expect(externalRedirectLink.error_message).toMatch(/redirected to https:\/\/example.com, but followRedirects is set to false/i)
+    expect(externalRedirectLink.error_message).toMatch(
+      /redirected to https:\/\/example.com, but followRedirects is set to false/i
+    )
   })
 
   // Scenario: Redirect loop when followRedirects is true (Puppeteer should eventually error out)
   it('should report a redirect loop as error when followRedirects is true', async () => {
     // This test might take a bit longer due to Puppeteer's retries for loops or timeouts
-    const resultsAsync = linkspector(configFileFollowTrue, { aliveStatusCodes: [200] }) // Ensure only 200 is "assumed alive"
+    const resultsAsync = linkspector(configFileFollowTrue, {
+      aliveStatusCodes: [200],
+    }) // Ensure only 200 is "assumed alive"
     const collectedResults = []
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const loopLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`)
+    const loopLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`
+    )
     expect(loopLink.status).toBe('error')
     // The error message might vary depending on how Puppeteer handles max redirects
     // e.g., "net::ERR_TOO_MANY_REDIRECTS" or similar
@@ -207,9 +241,13 @@ describe('followRedirects feature', () => {
     for await (const item of resultsAsync) {
       collectedResults.push(...item.result)
     }
-    const loopLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`)
+    const loopLink = collectedResults.find(
+      (r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`
+    )
     expect(loopLink.status).toBe('error')
     expect(loopLink.status_code).toBe(302) // The first redirect in the loop
-    expect(loopLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+    expect(loopLink.error_message).toMatch(
+      /redirected.*followRedirects is set to false/i
+    )
   })
 })

--- a/test/fixtures/redirects/redirects.test.js
+++ b/test/fixtures/redirects/redirects.test.js
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { linkspector } from '../../../linkspector.js' // Import from root linkspector.js
+import path from 'path'
+import http from 'http'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const fixturesDir = path.join(__dirname)
+// const markdownFile = path.join(fixturesDir, 'redirects.md') // No longer directly passed
+const configFileFollowFalse = path.join(fixturesDir, 'config-redirects-false.yml')
+const configFileFollowTrue = path.join(fixturesDir, 'config-redirects-true.yml')
+
+let server
+
+const PORT = 3000
+const HOST = 'localhost'
+
+const serverHandler = (req, res) => {
+  if (req.url === '/redirect-permanent') {
+    res.writeHead(301, { Location: `http://${HOST}:${PORT}/final-destination` })
+    res.end()
+  } else if (req.url === '/redirect-temporary') {
+    res.writeHead(302, { Location: `http://${HOST}:${PORT}/final-destination` })
+    res.end()
+  } else if (req.url === '/final-destination') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end('Final Destination Reached')
+  } else if (req.url === '/ok') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end('OK')
+  } else if (req.url === '/redirect-external') {
+    res.writeHead(301, { Location: 'https://example.com' })
+    res.end()
+  } else if (req.url === '/redirect-loop1') {
+    res.writeHead(302, { Location: `http://${HOST}:${PORT}/redirect-loop2` })
+    res.end()
+  } else if (req.url === '/redirect-loop2') {
+    res.writeHead(302, { Location: `http://${HOST}:${PORT}/redirect-loop1` })
+    res.end()
+  }
+  else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('Not Found')
+  }
+}
+
+describe('followRedirects feature', () => {
+  beforeAll(async () => {
+    server = http.createServer(serverHandler)
+    await new Promise((resolve) => server.listen(PORT, HOST, resolve))
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  // Scenario 1: followRedirects: true (default) - Permanent Redirect (301)
+  it('should report a permanent redirecting link as alive (200) when followRedirects is true (default)', async () => {
+    const resultsAsync = linkspector(configFileFollowTrue, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`)
+    expect(redirectLink.status).toBe('alive')
+    expect(redirectLink.status_code).toBe(200) // Final destination
+    expect(redirectLink.error_message).toContain('redirected to')
+  }, 10000) // Increased timeout to 10 seconds
+
+  // Scenario 1 (bis): followRedirects: true (default) - Temporary Redirect (302)
+  it('should report a temporary redirecting link as alive (200) when followRedirects is true (default)', async () => {
+    const resultsAsync = linkspector(configFileFollowTrue, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`)
+    expect(redirectLink.status).toBe('alive')
+    expect(redirectLink.status_code).toBe(200) // Final destination
+    expect(redirectLink.error_message).toContain('redirected to')
+  }, 10000) // Increased timeout
+
+  // Scenario 2: followRedirects: false - Permanent Redirect (301)
+  it('should report a permanent redirecting link as error (301) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-permanent`)
+    expect(redirectLink.status).toBe('error')
+    expect(redirectLink.status_code).toBe(301)
+    expect(redirectLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+  })
+
+  // Scenario 2 (bis): followRedirects: false - Temporary Redirect (302)
+  it('should report a temporary redirecting link as error (302) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const redirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-temporary`)
+    expect(redirectLink.status).toBe('error')
+    expect(redirectLink.status_code).toBe(302)
+    expect(redirectLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+  })
+
+  // Scenario 3: Non-redirecting link with followRedirects: false
+  it('should report a non-redirecting link as alive (200) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const okLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/ok`)
+    expect(okLink.status).toBe('alive')
+    expect(okLink.status_code).toBe(200)
+  })
+
+  // Scenario 4: Non-redirecting link with followRedirects: true (default)
+  it('should report a non-redirecting link as alive (200) when followRedirects is true (default)', async () => {
+    const resultsAsync = linkspector(configFileFollowTrue, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const okLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/ok`)
+    expect(okLink.status).toBe('alive')
+    expect(okLink.status_code).toBe(200)
+  })
+
+  // Scenario 5: Link that results in an actual error (404) with followRedirects: false
+  it('should report a 404 link as error (404) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const notFoundLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/not-found`)
+    expect(notFoundLink.status).toBe('error')
+    expect(notFoundLink.status_code).toBe(404)
+  })
+  
+  // Scenario: Link that results in an actual error (404) with followRedirects: true (default)
+  it('should report a 404 link as error (404) when followRedirects is true (default)', async () => {
+    const resultsAsync = linkspector(configFileFollowTrue, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const notFoundLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/not-found`)
+    expect(notFoundLink.status).toBe('error')
+    expect(notFoundLink.status_code).toBe(404)
+  })
+
+  // Scenario: External redirect allowed when followRedirects is true
+  it('should report an external redirecting link as alive (200 from example.com) when followRedirects is true', async () => {
+    const resultsAsync = linkspector(configFileFollowTrue, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const externalRedirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-external`)
+    expect(externalRedirectLink.status).toBe('alive')
+    // Note: status code might be from the final destination (example.com) if HEAD request works,
+    // or could be tricky if example.com blocks HEAD. Puppeteer fallback should handle it.
+    // For now, checking for 'alive' is the primary goal.
+    // expect(externalRedirectLink.status_code).toBe(200) // This can be flaky with external sites
+    expect(externalRedirectLink.error_message).toContain('redirected to https://example.com')
+  }, 10000) // Increased timeout
+
+  // Scenario: External redirect disallowed when followRedirects is false
+  it('should report an external redirecting link as error (301) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const externalRedirectLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-external`)
+    expect(externalRedirectLink.status).toBe('error')
+    expect(externalRedirectLink.status_code).toBe(301)
+    expect(externalRedirectLink.error_message).toMatch(/redirected to https:\/\/example.com, but followRedirects is set to false/i)
+  })
+
+  // Scenario: Redirect loop when followRedirects is true (Puppeteer should eventually error out)
+  it('should report a redirect loop as error when followRedirects is true', async () => {
+    // This test might take a bit longer due to Puppeteer's retries for loops or timeouts
+    const resultsAsync = linkspector(configFileFollowTrue, { aliveStatusCodes: [200] }) // Ensure only 200 is "assumed alive"
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const loopLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`)
+    expect(loopLink.status).toBe('error')
+    // The error message might vary depending on how Puppeteer handles max redirects
+    // e.g., "net::ERR_TOO_MANY_REDIRECTS" or similar
+    expect(loopLink.error_message).toBeDefined()
+  }, 20000) // Timeout already increased, keeping it
+
+  // Scenario: Redirect loop when followRedirects is false
+  it('should report a redirect loop as error (first redirect status) when followRedirects is false', async () => {
+    const resultsAsync = linkspector(configFileFollowFalse, {})
+    const collectedResults = []
+    for await (const item of resultsAsync) {
+      collectedResults.push(...item.result)
+    }
+    const loopLink = collectedResults.find((r) => r.link === `http://${HOST}:${PORT}/redirect-loop1`)
+    expect(loopLink.status).toBe('error')
+    expect(loopLink.status_code).toBe(302) // The first redirect in the loop
+    expect(loopLink.error_message).toMatch(/redirected.*followRedirects is set to false/i)
+  })
+})


### PR DESCRIPTION
## Description

AI generated.

This commit introduces a new configuration option, `followRedirects`, to control how HTTP redirects are handled by the link checker.

The `followRedirects` option can be set in the configuration file (e.g., `.linkspector.yml`):
- Type: boolean
- Default: `true`

Behavior:
- When `followRedirects` is `true` (default), links that redirect will be followed to their final destination. The status of the final destination will be reported.
- When `followRedirects` is `false`, if a link redirects, it will be reported as an 'error'. The original redirect status code (e.g., 301, 302) will be reported, and the link checker will not follow the redirect.

This feature allows you to identify and potentially fail checks for links that redirect, which can be useful for maintaining up-to-date and direct links.

Changes include:
- Added `followRedirects` to the configuration schema in `lib/validate-config.js`.
- Updated `lib/batch-check-links.js` to:
    - Respect the `followRedirects` option for both `fetch` and Puppeteer requests.
    - Report redirects as errors when `followRedirects` is `false`.
- Added a comprehensive test suite in `test/fixtures/redirects/` using Vitest, including a mock HTTP server to simulate various redirect scenarios.
- Updated `README.md` with documentation for the new option.

Fixes #121 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Information

Include any additional information about the pull request here.
