### PR TITLE
feat: implement RDJSON validation and fixing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To check hyperlinks in your markup language files, follow these steps:
      linkspector check -j
      ```
 
-     The JSON output follows [rdjson](https://github.com/reviewdog/reviewdog/tree/master/proto/rdf#rdjson) format.
+     The JSON output follows [rdjson](https://github.com/reviewdog/reviewdog/tree/master/proto/rdf#rdjson) format. Linkspector automatically validates and fixes the RDJSON output using the [@umbrelladocs/rdformat-validator](https://www.npmjs.com/package/@umbrelladocs/rdformat-validator) package to ensure compliance with the RDJSON specification.
 
 1. Linkspector starts checking the hyperlinks in your files based on the configuration provided in the configuration file or using the default configuration. It then displays the results in your terminal.
 

--- a/index.test.js
+++ b/index.test.js
@@ -34,7 +34,7 @@ test('linkspector should check top-level relative links in Markdown file', async
   }
 
   expect(hasErrorLinks).toBe(false)
-  expect(results.length).toBe(23)
+  expect(results.length).toBe(24)
 })
 
 test('linkspector should track statistics correctly when stats option is enabled', async () => {
@@ -87,7 +87,7 @@ test('linkspector should track statistics correctly when stats option is enabled
 
   // Verify statistics are being tracked correctly
   expect(stats.filesChecked).toBeGreaterThan(0)
-  expect(stats.totalLinks).toBe(23)
+  expect(stats.totalLinks).toBe(24)
   expect(stats.totalLinks).toBe(
     stats.httpLinks +
       stats.fileLinks +

--- a/lib/validate-rdjson.js
+++ b/lib/validate-rdjson.js
@@ -1,0 +1,165 @@
+/**
+ * Validates and fixes RDJSON output using the @umbrelladocs/rdformat-validator package
+ *
+ * @param {Object} rdjsonData - The RDJSON data to validate and fix
+ * @returns {Promise<Object>} - Object containing validation result and fixed data or error message
+ */
+
+import { validateAndFix } from '@umbrelladocs/rdformat-validator'
+
+/**
+ * Validates and fixes RDJSON data
+ * @param {Object} rdjsonData - The RDJSON data to validate and fix
+ * @returns {Promise<Object>} - Result object with validation status and fixed data or error
+ */
+export async function validateAndFixRDJSON(rdjsonData) {
+  try {
+    // Ensure input is an object
+    if (!rdjsonData || typeof rdjsonData !== 'object') {
+      return {
+        success: false,
+        data: null,
+        message: 'Invalid input: RDJSON data must be an object',
+      }
+    }
+
+    // First validate and attempt to fix the RDJSON data
+    const result = await validateAndFix(rdjsonData, {
+      fixLevel: 'basic', // Start with basic fixes
+      strictMode: false,
+      allowExtraFields: true,
+    })
+
+    if (result.valid) {
+      // Data is valid, return as-is or with fixes applied
+      return {
+        success: true,
+        data: result.fixedData || rdjsonData,
+        appliedFixes: result.appliedFixes || [],
+        message:
+          result.appliedFixes && result.appliedFixes.length > 0
+            ? `RDJSON validated and ${result.appliedFixes.length} fixes applied`
+            : 'RDJSON is valid',
+      }
+    } else {
+      // Try aggressive fixing if basic fixing didn't work
+      const aggressiveResult = await validateAndFix(rdjsonData, {
+        fixLevel: 'aggressive',
+        strictMode: false,
+        allowExtraFields: true,
+      })
+
+      if (aggressiveResult.valid && aggressiveResult.fixedData) {
+        return {
+          success: true,
+          data: aggressiveResult.fixedData,
+          appliedFixes: aggressiveResult.appliedFixes || [],
+          message: `RDJSON fixed with aggressive mode - ${aggressiveResult.appliedFixes?.length || 0} fixes applied`,
+        }
+      } else {
+        // Both validation and fixing failed
+        const errorMessages =
+          result.errors
+            ?.map((err) => `${err.path}: ${err.message}`)
+            .join('; ') || 'Unknown validation errors'
+
+        return {
+          success: false,
+          data: null,
+          errors: result.errors || [],
+          message: `RDJSON validation failed: ${errorMessages}`,
+        }
+      }
+    }
+  } catch (error) {
+    // Handle unexpected errors during validation/fixing
+    return {
+      success: false,
+      data: null,
+      error: error.message,
+      message: `RDJSON validation/fixing process failed: ${error.message}`,
+    }
+  }
+}
+
+/**
+ * Ensures minimal RDJSON structure when no diagnostics are present
+ * @param {boolean} hasErrors - Whether there are any error links
+ * @returns {Object} - Minimal valid RDJSON structure
+ */
+export function createEmptyRDJSON(hasErrors = false) {
+  return {
+    source: {
+      name: 'linkspector',
+      url: 'https://github.com/UmbrellaDocs/linkspector',
+    },
+    severity: hasErrors ? 'ERROR' : 'INFO',
+    diagnostics: [],
+  }
+}
+
+/**
+ * Validates a diagnostic object and ensures it has all required fields
+ * @param {Object} diagnostic - The diagnostic object to validate
+ * @param {string} filePath - The file path for the diagnostic
+ * @returns {Object} - Validated and corrected diagnostic object
+ */
+export function validateDiagnostic(diagnostic, filePath) {
+  // Ensure diagnostic is an object
+  if (!diagnostic || typeof diagnostic !== 'object') {
+    return {
+      message: 'Unknown error',
+      location: {
+        path: filePath || 'unknown',
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 1 },
+        },
+      },
+      severity: 'ERROR',
+    }
+  }
+
+  const validatedDiagnostic = {
+    message: diagnostic.message || 'Unknown error',
+    location: {
+      path: filePath || diagnostic.location?.path || 'unknown',
+      range: {
+        start: {
+          line: Math.max(1, diagnostic.location?.range?.start?.line || 1),
+          column: Math.max(1, diagnostic.location?.range?.start?.column || 1),
+        },
+        end: {
+          line: Math.max(
+            1,
+            diagnostic.location?.range?.end?.line ||
+              diagnostic.location?.range?.start?.line ||
+              1
+          ),
+          column: Math.max(
+            1,
+            diagnostic.location?.range?.end?.column ||
+              diagnostic.location?.range?.start?.column ||
+              1
+          ),
+        },
+      },
+    },
+    severity: diagnostic.severity || 'ERROR',
+  }
+
+  // Add optional fields if they exist and are valid
+  if (
+    diagnostic.source &&
+    (typeof diagnostic.source === 'string' ||
+      typeof diagnostic.source === 'object')
+  ) {
+    validatedDiagnostic.source = diagnostic.source
+  }
+
+  if (diagnostic.code) {
+    validatedDiagnostic.code = diagnostic.code
+  }
+
+  return validatedDiagnostic
+}

--- a/lib/validate-rdjson.js
+++ b/lib/validate-rdjson.js
@@ -8,6 +8,28 @@
 import { validateAndFix } from '@umbrelladocs/rdformat-validator'
 
 /**
+ * Creates validation configuration for the validateAndFix function
+ * @param {string} fixLevel - The fix level ('basic' or 'aggressive')
+ * @returns {Object} - Configuration object for validation
+ */
+function getValidationConfig(fixLevel = 'basic') {
+  return {
+    fixLevel,
+    strictMode: false,
+    allowExtraFields: true,
+  }
+}
+
+/**
+ * Ensures a number is at least 1 (positive)
+ * @param {number} value - The value to check
+ * @returns {number} - The value if >= 1, otherwise 1
+ */
+function ensurePositiveNumber(value) {
+  return Math.max(1, value || 1)
+}
+
+/**
  * Validates and fixes RDJSON data
  * @param {Object} rdjsonData - The RDJSON data to validate and fix
  * @returns {Promise<Object>} - Result object with validation status and fixed data or error
@@ -24,11 +46,10 @@ export async function validateAndFixRDJSON(rdjsonData) {
     }
 
     // First validate and attempt to fix the RDJSON data
-    const result = await validateAndFix(rdjsonData, {
-      fixLevel: 'basic', // Start with basic fixes
-      strictMode: false,
-      allowExtraFields: true,
-    })
+    const result = await validateAndFix(
+      rdjsonData,
+      getValidationConfig('basic')
+    )
 
     if (result.valid) {
       // Data is valid, return as-is or with fixes applied
@@ -43,11 +64,10 @@ export async function validateAndFixRDJSON(rdjsonData) {
       }
     } else {
       // Try aggressive fixing if basic fixing didn't work
-      const aggressiveResult = await validateAndFix(rdjsonData, {
-        fixLevel: 'aggressive',
-        strictMode: false,
-        allowExtraFields: true,
-      })
+      const aggressiveResult = await validateAndFix(
+        rdjsonData,
+        getValidationConfig('aggressive')
+      )
 
       if (aggressiveResult.valid && aggressiveResult.fixedData) {
         return {
@@ -126,21 +146,19 @@ export function validateDiagnostic(diagnostic, filePath) {
       path: filePath || diagnostic.location?.path || 'unknown',
       range: {
         start: {
-          line: Math.max(1, diagnostic.location?.range?.start?.line || 1),
-          column: Math.max(1, diagnostic.location?.range?.start?.column || 1),
+          line: ensurePositiveNumber(diagnostic.location?.range?.start?.line),
+          column: ensurePositiveNumber(
+            diagnostic.location?.range?.start?.column
+          ),
         },
         end: {
-          line: Math.max(
-            1,
+          line: ensurePositiveNumber(
             diagnostic.location?.range?.end?.line ||
-              diagnostic.location?.range?.start?.line ||
-              1
+              diagnostic.location?.range?.start?.line
           ),
-          column: Math.max(
-            1,
+          column: ensurePositiveNumber(
             diagnostic.location?.range?.end?.column ||
-              diagnostic.location?.range?.start?.column ||
-              1
+              diagnostic.location?.range?.start?.column
           ),
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrelladocs/linkspector",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
+        "@umbrelladocs/rdformat-validator": "^1.0.0",
         "commander": "^14.0.0",
         "github-slugger": "^2.0.0",
         "glob": "^11.0.3",
@@ -973,6 +974,26 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@umbrelladocs/rdformat-validator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@umbrelladocs/rdformat-validator/-/rdformat-validator-1.0.0.tgz",
+      "integrity": "sha512-HRQI1QbbQJoVIlPhn/P30aW2fEyLj2gvZQt/Gbkae/dtCEeB9fEvWdpoI6GMY0eVRzg9KWL16I9Q7Awg3M77hA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "rdformat-validator": "bin/rdformat-validator.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/UmbrellaDocs"
       }
     },
     "node_modules/@vitest/expect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbrelladocs/linkspector",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@umbrelladocs/rdformat-validator": "^1.0.0",
@@ -18,7 +18,7 @@
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
         "ora": "^8.2.0",
-        "puppeteer": "^24.11.1",
+        "puppeteer": "^24.14.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
@@ -582,9 +582,9 @@
       "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
-      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.1",
@@ -592,7 +592,7 @@
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
         "semver": "^7.7.2",
-        "tar-fs": "^3.0.8",
+        "tar-fs": "^3.1.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -1187,16 +1187,16 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
+      "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
-      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
-      "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.1.1.tgz",
+      "integrity": "sha512-L2BKQ0rSLADgbPMIdDh3wnYHs3EiUiMay2Sq0CTolheaADmWIf6Pe+T9LJRcnh5rcMz0U7MVk0cQVvKsGRMa1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -3336,17 +3336,17 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.11.1.tgz",
-      "integrity": "sha512-QbccB/LgxX4tSZRzr9KQ1Jajdvu3n35Dlf/Otjz0QfR+6mDoZdMWLcWF94uQoC3OJerCyYm5hlU2Ru4nBoId2A==",
+      "version": "24.14.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.14.0.tgz",
+      "integrity": "sha512-GB7suRDkp9pUnxpNGAORICQCtw11KFbg6U2iJXVTflzJLK5D1qzq8xOOmLgN/QnDBpDMdpn96ri52XkuN83Giw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
+        "@puppeteer/browsers": "2.10.6",
+        "chromium-bidi": "7.1.1",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1464554",
-        "puppeteer-core": "24.11.1",
+        "puppeteer-core": "24.14.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -3357,17 +3357,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.11.1.tgz",
-      "integrity": "sha512-I0Gv3jWBRY9E3NTBElp7br7Gaid5RbFTxCRRMHym1kCf0ompO0Pel4REGsGDwMWkg3uwFzIH7t7qXs3T4DKRWA==",
+      "version": "24.14.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.14.0.tgz",
+      "integrity": "sha512-NO9XpCl+i8oB0zJp81iPhzMo2QK8/JTj4ramSvTpGCo9CPCNo4AZ8qVOGpSgXzlcOfOT3VHOkzTfPo08GOE5jA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
+        "@puppeteer/browsers": "2.10.6",
+        "chromium-bidi": "7.1.1",
         "debug": "^4.4.1",
         "devtools-protocol": "0.0.1464554",
         "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.2"
+        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=18"
@@ -3555,9 +3555,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
-      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -4420,9 +4420,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",
@@ -57,7 +57,7 @@
     "js-yaml": "^4.1.0",
     "kleur": "^4.1.5",
     "ora": "^8.2.0",
-    "puppeteer": "^24.11.1",
+    "puppeteer": "^24.14.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "homepage": "https://github.com/UmbrellaDocs/linkspector#readme",
   "dependencies": {
+    "@umbrelladocs/rdformat-validator": "^1.0.0",
     "commander": "^14.0.0",
     "github-slugger": "^2.0.0",
     "glob": "^11.0.3",
@@ -63,7 +64,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "vitest": "^3.2.4",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/test/fixtures/rdjson-validation/rdjson-integration.test.js
+++ b/test/fixtures/rdjson-validation/rdjson-integration.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { linkspector } from '../../../linkspector.js'
+import path from 'path'
+
+describe('RDJSON Integration Tests', () => {
+  const fixturesPath = path.join(
+    process.cwd(),
+    'test/fixtures/rdjson-validation'
+  )
+
+  it('should produce valid RDJSON output for files with broken links', async () => {
+    const configFile = path.join(fixturesPath, 'test-config.yml')
+    const cmd = { json: true }
+
+    let results = {
+      source: {
+        name: 'linkspector',
+        url: 'https://github.com/UmbrellaDocs/linkspector',
+      },
+      severity: 'ERROR',
+      diagnostics: [],
+    }
+
+    let hasErrors = false
+
+    for await (const { file, result } of linkspector(configFile, cmd)) {
+      for (const linkStatusObj of result) {
+        if (linkStatusObj.status === 'error') {
+          hasErrors = true
+          results.diagnostics.push({
+            message: `Cannot reach ${linkStatusObj.link} Status: ${linkStatusObj.status_code}${linkStatusObj.error_message ? ` ${linkStatusObj.error_message}` : ''}`,
+            location: {
+              path: file,
+              range: {
+                start: {
+                  line: linkStatusObj.line_number,
+                  column: linkStatusObj.position.start.column,
+                },
+                end: {
+                  line: linkStatusObj.position.end.line,
+                  column: linkStatusObj.position.end.column,
+                },
+              },
+            },
+            severity: linkStatusObj.status.toUpperCase(),
+          })
+        }
+      }
+    }
+
+    // Verify RDJSON structure
+    expect(results).toHaveProperty('source')
+    expect(results.source).toHaveProperty('name', 'linkspector')
+    expect(results.source).toHaveProperty(
+      'url',
+      'https://github.com/UmbrellaDocs/linkspector'
+    )
+    expect(results).toHaveProperty('severity', 'ERROR')
+    expect(results).toHaveProperty('diagnostics')
+    expect(Array.isArray(results.diagnostics)).toBe(true)
+
+    if (hasErrors) {
+      expect(results.diagnostics.length).toBeGreaterThan(0)
+
+      // Verify each diagnostic has required fields
+      results.diagnostics.forEach((diagnostic) => {
+        expect(diagnostic).toHaveProperty('message')
+        expect(diagnostic).toHaveProperty('location')
+        expect(diagnostic.location).toHaveProperty('path')
+        expect(diagnostic.location).toHaveProperty('range')
+        expect(diagnostic.location.range).toHaveProperty('start')
+        expect(diagnostic.location.range.start).toHaveProperty('line')
+        expect(diagnostic.location.range.start).toHaveProperty('column')
+        expect(diagnostic).toHaveProperty('severity')
+      })
+    }
+  }, 30000) // 30 second timeout for network requests
+
+  it('should produce valid RDJSON output for files with no broken links', async () => {
+    const configFile = path.join(fixturesPath, 'test-config-valid.yml')
+    const cmd = { json: true }
+
+    let results = {
+      source: {
+        name: 'linkspector',
+        url: 'https://github.com/UmbrellaDocs/linkspector',
+      },
+      severity: 'INFO',
+      diagnostics: [],
+    }
+
+    for await (const { file, result } of linkspector(configFile, cmd)) {
+      for (const linkStatusObj of result) {
+        if (linkStatusObj.status === 'error') {
+          results.diagnostics.push({
+            message: `Cannot reach ${linkStatusObj.link}`,
+            location: {
+              path: file,
+              range: {
+                start: {
+                  line: linkStatusObj.line_number,
+                  column: linkStatusObj.position.start.column,
+                },
+                end: {
+                  line: linkStatusObj.position.end.line,
+                  column: linkStatusObj.position.end.column,
+                },
+              },
+            },
+            severity: 'ERROR',
+          })
+        }
+      }
+    }
+
+    // Verify RDJSON structure for success case
+    expect(results).toHaveProperty('source')
+    expect(results.source).toHaveProperty('name', 'linkspector')
+    expect(results.source).toHaveProperty(
+      'url',
+      'https://github.com/UmbrellaDocs/linkspector'
+    )
+    expect(results).toHaveProperty('severity', 'INFO')
+    expect(results).toHaveProperty('diagnostics')
+    expect(Array.isArray(results.diagnostics)).toBe(true)
+    expect(results.diagnostics.length).toBe(0)
+  }, 30000) // 30 second timeout for network requests
+})

--- a/test/fixtures/rdjson-validation/test-config-valid.yml
+++ b/test/fixtures/rdjson-validation/test-config-valid.yml
@@ -1,0 +1,6 @@
+files:
+  - ./test/fixtures/rdjson-validation/test-links-valid.md
+aliveStatusCodes:
+  - 200
+  - 301
+  - 302

--- a/test/fixtures/rdjson-validation/test-config.yml
+++ b/test/fixtures/rdjson-validation/test-config.yml
@@ -1,0 +1,6 @@
+files:
+  - ./test/fixtures/rdjson-validation/test-links.md
+aliveStatusCodes:
+  - 200
+  - 301
+  - 302

--- a/test/fixtures/rdjson-validation/test-links-valid.md
+++ b/test/fixtures/rdjson-validation/test-links-valid.md
@@ -1,0 +1,8 @@
+# Test Document with Valid Links
+
+This is a test document with only valid links:
+
+- [GitHub](https://github.com)
+- [Google](https://google.com)
+
+Some text here.

--- a/test/fixtures/rdjson-validation/test-links.md
+++ b/test/fixtures/rdjson-validation/test-links.md
@@ -1,0 +1,9 @@
+# Test Document
+
+This is a test document with some links:
+
+- [Valid link](https://github.com)
+- [Broken link](https://this-domain-definitely-does-not-exist-12345.com)
+- [Another broken link](https://broken-link-example-xyz.invalid)
+
+Some text here.

--- a/test/fixtures/rdjson-validation/test.md
+++ b/test/fixtures/rdjson-validation/test.md
@@ -1,0 +1,3 @@
+# Test
+
+[broken](https://invalid-url-12345.example.com)

--- a/test/fixtures/rdjson-validation/test.yml
+++ b/test/fixtures/rdjson-validation/test.yml
@@ -1,0 +1,2 @@
+files:
+  - ./test/fixtures/rdjson-validation/test.md

--- a/test/fixtures/rdjson-validation/validate-rdjson.test.js
+++ b/test/fixtures/rdjson-validation/validate-rdjson.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateAndFixRDJSON,
+  createEmptyRDJSON,
+  validateDiagnostic,
+} from '../../../lib/validate-rdjson.js'
+
+describe('RDJSON Validation', () => {
+  it('should validate valid RDJSON data', async () => {
+    const validData = {
+      source: {
+        name: 'linkspector',
+        url: 'https://github.com/UmbrellaDocs/linkspector',
+      },
+      severity: 'ERROR',
+      diagnostics: [],
+    }
+
+    const result = await validateAndFixRDJSON(validData)
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(validData)
+    expect(result.message).toBe('RDJSON is valid')
+  })
+
+  it('should create empty RDJSON structure', () => {
+    const emptyWithErrors = createEmptyRDJSON(true)
+    expect(emptyWithErrors.severity).toBe('ERROR')
+    expect(emptyWithErrors.diagnostics).toEqual([])
+
+    const emptyWithoutErrors = createEmptyRDJSON(false)
+    expect(emptyWithoutErrors.severity).toBe('INFO')
+    expect(emptyWithoutErrors.diagnostics).toEqual([])
+  })
+
+  it('should validate and fix diagnostic objects', () => {
+    const diagnostic = validateDiagnostic(
+      {
+        message: 'Test error',
+        location: {
+          path: 'test.md',
+          range: {
+            start: { line: 5 },
+          },
+        },
+      },
+      'test.md'
+    )
+
+    expect(diagnostic.message).toBe('Test error')
+    expect(diagnostic.location.path).toBe('test.md')
+    expect(diagnostic.location.range.start.line).toBe(5)
+    expect(diagnostic.location.range.start.column).toBe(1)
+    expect(diagnostic.location.range.end.line).toBe(5)
+    expect(diagnostic.location.range.end.column).toBe(1)
+    expect(diagnostic.severity).toBe('ERROR')
+  })
+
+  it('should handle invalid diagnostic objects', () => {
+    const diagnostic = validateDiagnostic({}, 'test.md')
+
+    expect(diagnostic.message).toBe('Unknown error')
+    expect(diagnostic.location.path).toBe('test.md')
+    expect(diagnostic.location.range.start.line).toBe(1)
+    expect(diagnostic.location.range.start.column).toBe(1)
+    expect(diagnostic.severity).toBe('ERROR')
+  })
+
+  it('should handle invalid line numbers', () => {
+    const diagnostic = validateDiagnostic(
+      {
+        message: 'Test',
+        location: {
+          path: 'test.md',
+          range: {
+            start: { line: -5, column: 0 },
+            end: { line: 0, column: -1 },
+          },
+        },
+      },
+      'test.md'
+    )
+
+    expect(diagnostic.location.range.start.line).toBe(1)
+    expect(diagnostic.location.range.start.column).toBe(1)
+    expect(diagnostic.location.range.end.line).toBe(1)
+    expect(diagnostic.location.range.end.column).toBe(1)
+  })
+
+  it('should handle null or undefined input', async () => {
+    const result1 = await validateAndFixRDJSON(null)
+    expect(result1.success).toBe(false)
+    expect(result1.message).toBe('Invalid input: RDJSON data must be an object')
+
+    const result2 = await validateAndFixRDJSON(undefined)
+    expect(result2.success).toBe(false)
+    expect(result2.message).toBe('Invalid input: RDJSON data must be an object')
+  })
+})


### PR DESCRIPTION
## Description

- Add validateAndFixRDJSON, createEmptyRDJSON, and validateDiagnostic functions
- Integrate RDJSON validation in the linkspector output process
- Update README with RDJSON validation details
- Add tests for RDJSON validation and diagnostics
- Update dependencies to include @umbrelladocs/rdformat-validator

Fixes #114 
Fixes #134

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

