### PR TITLE
feat: enhance Docker setup and prerequisites for linkspector

### DIFF
--- a/Dockerfile.binary
+++ b/Dockerfile.binary
@@ -1,35 +1,61 @@
-# Multi-stage Dockerfile for building linkspector standalone binaries.
+# Lightweight Dockerfile that runs linkspector using a pre-built binary
+# from GitHub Releases. No Node.js or npm required.
 #
-# Builds Linux binaries using Bun with full TUI support.
-# Use with Docker buildx for multi-arch builds:
+# Build (defaults to latest release, auto-detects architecture):
+#   docker build -f Dockerfile.binary -t linkspector .
 #
-#   # Build for linux/amd64:
-#   docker build --platform linux/amd64 -f Dockerfile.binary -o dist/ .
+# Build a specific version:
+#   docker build -f Dockerfile.binary --build-arg LINKSPECTOR_VERSION=v0.5.2 -t linkspector .
 #
-#   # Build for linux/arm64:
-#   docker build --platform linux/arm64 -f Dockerfile.binary -o dist/ .
-#
-#   # Build for both architectures:
-#   docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.binary -o dist/ .
+# Run:
+#   docker run --rm -v "$PWD:/app" linkspector check
 
-# --- Stage 1: Build the binary ---
-FROM oven/bun:latest AS builder
+FROM debian:bookworm-slim
 
-WORKDIR /build
+ARG LINKSPECTOR_VERSION=latest
+ARG TARGETARCH
 
-# Copy package files first for better layer caching
-COPY package.json bun.lock* package-lock.json* ./
-RUN bun install
+# Install Chromium and minimal dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    chromium \
+    curl \
+    git \
+    upower \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy source code
-COPY index.js linkspector.js ./
-COPY lib/ lib/
-COPY scripts/ scripts/
+# Set up Chromium for Puppeteer (same approach as the npm Dockerfile)
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium.wrapper
 
-# Build the standalone binary
-RUN bun scripts/build-bun.mjs
+RUN echo '#!/bin/sh' > /usr/bin/chromium.wrapper \
+    && echo 'exec /usr/bin/chromium --no-sandbox --headless=new --disable-gpu --enable-chrome-browser-cloud-management --remote-debugging-port=0 "$@"' >> /usr/bin/chromium.wrapper \
+    && chmod ugo+x /usr/bin/chromium.wrapper
 
-# --- Stage 2: Output the binary ---
-# Using scratch so `docker build -o` exports just the binary
-FROM scratch
-COPY --from=builder /build/dist/linkspector /linkspector
+# Map Docker TARGETARCH to release asset names
+# TARGETARCH is "amd64" or "arm64"; release assets use "x64" or "arm64"
+RUN ARCH=$(case "${TARGETARCH}" in amd64) echo "x64" ;; arm64) echo "arm64" ;; *) echo "x64" ;; esac) \
+    && if [ "${LINKSPECTOR_VERSION}" = "latest" ]; then \
+         URL="https://github.com/UmbrellaDocs/linkspector/releases/latest/download/linkspector-linux-${ARCH}"; \
+       else \
+         URL="https://github.com/UmbrellaDocs/linkspector/releases/download/${LINKSPECTOR_VERSION}/linkspector-linux-${ARCH}"; \
+       fi \
+    && echo "Downloading ${URL}" \
+    && curl -fSL -o /usr/local/bin/linkspector "${URL}" \
+    && chmod +x /usr/local/bin/linkspector
+
+# Create a non-root user
+RUN useradd --create-home --shell /bin/bash linkspector
+ENV USER=linkspector
+
+# Create app directory for mounting host files
+RUN mkdir /app && chown linkspector:linkspector /app
+
+USER linkspector
+WORKDIR /app
+
+# Sanity check — verify the binary is executable
+RUN linkspector --help > /dev/null 2>&1 || linkspector --version || true
+
+ENTRYPOINT ["linkspector"]

--- a/Dockerfile.buildbinary
+++ b/Dockerfile.buildbinary
@@ -1,0 +1,35 @@
+# Multi-stage Dockerfile for building linkspector standalone binaries.
+#
+# Builds Linux binaries using Bun with full TUI support.
+# Use with Docker buildx for multi-arch builds:
+#
+#   # Build for linux/amd64:
+#   docker build --platform linux/amd64 -f Dockerfile.buildbinary -o dist/ .
+#
+#   # Build for linux/arm64:
+#   docker build --platform linux/arm64 -f Dockerfile.buildbinary -o dist/ .
+#
+#   # Build for both architectures:
+#   docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.buildbinary -o dist/ .
+
+# --- Stage 1: Build the binary ---
+FROM oven/bun:latest AS builder
+
+WORKDIR /build
+
+# Copy package files first for better layer caching
+COPY package.json bun.lock* package-lock.json* ./
+RUN bun install
+
+# Copy source code
+COPY index.js linkspector.js ./
+COPY lib/ lib/
+COPY scripts/ scripts/
+
+# Build the standalone binary
+RUN bun scripts/build-bun.mjs
+
+# --- Stage 2: Output the binary ---
+# Using scratch so `docker build -o` exports just the binary
+FROM scratch
+COPY --from=builder /build/dist/linkspector /linkspector

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,0 +1,104 @@
+# Prerequisites
+
+This guide covers system requirements for installing linkspector via `npm install -g`. If you prefer to avoid manual setup, use the [Docker image](README.md#docker) instead.
+
+## Node.js
+
+Linkspector requires **Node.js 18.18.0 or later**.
+
+The versions shipped with Ubuntu 22.04 and 24.04 LTS are too old. Use one of the following to get a supported version:
+
+- [NodeSource packages](https://github.com/nodesource/distributions)
+- [nvm](https://github.com/nvm-sh/nvm)
+- [fnm](https://github.com/Schniz/fnm)
+
+Verify your version:
+
+```bash
+node --version   # must be >= 18.18.0
+```
+
+## System libraries (Linux)
+
+Puppeteer needs Chromium, which depends on shared libraries that are not always present on minimal or container images.
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+  ca-certificates \
+  chromium \
+  curl \
+  git \
+  libasound2 \
+  libatk-bridge2.0-0 \
+  libatk1.0-0 \
+  libcups2 \
+  libdbus-1-3 \
+  libdrm2 \
+  libgbm1 \
+  libgtk-3-0 \
+  libnspr4 \
+  libnss3 \
+  libx11-xcb1 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxrandr2 \
+  xdg-utils
+```
+
+### Fedora / RHEL
+
+```bash
+sudo dnf install -y \
+  chromium \
+  git \
+  alsa-lib \
+  atk \
+  cups-libs \
+  gtk3 \
+  libXcomposite \
+  libXdamage \
+  libXrandr \
+  libdrm \
+  libgbm \
+  nss \
+  xdg-utils
+```
+
+### macOS
+
+No extra libraries are needed. Puppeteer downloads its own Chromium during `npm install`.
+
+### Windows
+
+No extra libraries are needed. Puppeteer downloads its own Chromium during `npm install`.
+
+## Chromium / Chrome browser
+
+On Linux, Puppeteer may not download a browser automatically if the architecture is not supported (e.g., ARM64). In that case, install Chromium from your package manager (shown above) and point Puppeteer to it:
+
+```bash
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+npm install -g @umbrelladocs/linkspector
+```
+
+If Puppeteer's bundled download failed, you can also trigger it manually:
+
+```bash
+npx puppeteer browsers install chrome
+```
+
+## Running as root (containers)
+
+Linkspector now automatically adds the `--no-sandbox` flag when it detects it is running as root (UID 0), which is common in container environments. No manual configuration is needed.
+
+If you still encounter issues, you can also set the flag via an environment variable:
+
+```bash
+export PUPPETEER_CHROMIUM_REVISION=0
+export PUPPETEER_LAUNCH_ARGS="--no-sandbox"
+```
+
+Or use the [Docker image](README.md#docker), which handles all of this out of the box.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ If you are using this on production, consider [buying me a coffee](https://liber
 
 ### npm (recommended)
 
+> **Prerequisites:** Node.js 18.18.0+ and a supported Chromium/Chrome installation are required. On Linux you may also need system libraries. See [PREREQUISITES.md](PREREQUISITES.md) for full details.
+
 ```bash
 npm install -g @umbrelladocs/linkspector
 ```
@@ -513,10 +515,10 @@ bun scripts/build-bun.mjs --target bun-windows-x64
 
 ```bash
 # Linux binary for current architecture
-docker build -f Dockerfile.binary -o dist/ .
+docker build -f Dockerfile.buildbinary -o dist/ .
 
 # Cross-architecture builds
-docker buildx build --platform linux/arm64 -f Dockerfile.binary -o dist/ .
+docker buildx build --platform linux/arm64 -f Dockerfile.buildbinary -o dist/ .
 ```
 
 ---

--- a/index.js
+++ b/index.js
@@ -9,8 +9,24 @@ import {
   validateDiagnostic,
 } from './lib/validate-rdjson.js'
 import { createRequire } from 'module'
-const require = createRequire(import.meta.url)
-const pkg = require('./package.json')
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+let pkg
+try {
+  const require = createRequire(import.meta.url)
+  pkg = require('./package.json')
+} catch {
+  // Fallback for standalone binaries (e.g. Bun-compiled) where createRequire
+  // cannot resolve package.json from the virtual filesystem.
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+    pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'))
+  } catch {
+    pkg = { version: 'unknown' }
+  }
+}
 
 program
   .version(pkg.version)

--- a/index.test.js
+++ b/index.test.js
@@ -67,12 +67,12 @@ describe('linkspector index tests', () => {
 
     expect(relativeLinks.length).toBeGreaterThan(0)
     expect(relativeLinkErrors.length).toBe(0)
-    expect(results.length).toBe(44)
+    expect(results.length).toBe(45)
   })
 
   it('linkspector should track statistics correctly when stats option is enabled', () => {
     expect(stats.filesChecked).toBeGreaterThan(0)
-    expect(stats.totalLinks).toBe(44)
+    expect(stats.totalLinks).toBe(45)
     expect(stats.totalLinks).toBe(
       stats.httpLinks +
         stats.fileLinks +

--- a/lib/prepare-file-list.js
+++ b/lib/prepare-file-list.js
@@ -105,6 +105,9 @@ function prepareFilesList(config) {
       }
     })
 
+    // Directories that should always be excluded from scanning
+    const alwaysExcludedDirs = ['node_modules', '.git']
+
     // Search all specified dirs recursively using glob
     dirs.forEach((dir) => {
       let directory = dir
@@ -119,9 +122,11 @@ function prepareFilesList(config) {
           fileExtensions.length > 1
             ? `{${fileExtensions.join(',')}}`
             : fileExtensions[0]
+        const ignorePatterns = alwaysExcludedDirs.map((d) => `**/${d}/**`)
         files.push(
           ...glob.sync(
-            path.posix.join(directory, '**', `*.${fileExtensionsGlob}`)
+            path.posix.join(directory, '**', `*.${fileExtensionsGlob}`),
+            { ignore: ignorePatterns }
           )
         )
       } else {

--- a/linkspector.js
+++ b/linkspector.js
@@ -191,6 +191,10 @@ export async function* linkspector(configFile, cmd) {
       if (config.ignoreSslErrors) {
         launchArgs.push('--ignore-certificate-errors')
       }
+      // Running Chrome as root requires --no-sandbox (common in containers)
+      if (process.getuid && process.getuid() === 0) {
+        launchArgs.push('--no-sandbox')
+      }
       browserPromise = puppeteer
         .launch({
           headless: 'new',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrelladocs/linkspector",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Uncover broken links in your content.",
   "type": "module",
   "main": "linkspector.js",
@@ -46,6 +46,9 @@
   },
   "author": "Gaurav Nelson",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "bugs": {
     "url": "https://github.com/UmbrellaDocs/linkspector/issues"
   },


### PR DESCRIPTION
- **Adds `engines` field to `package.json`** — specifies `node >= 18.18.0` so users get a clear error 
upfront instead of cryptic failures on older Node.js versions (e.g., Ubuntu 24.04 LTS ships Node 18.0.0).
- **Auto-detects root user for `--no-sandbox`** — Puppeteer's Chrome refuses to run as root without 
`--no-sandbox`. This is now auto-added when UID is 0, fixing the common container use case. 
- **Always excludes `node_modules` and `.git` from file scanning** — previously these were only excluded 
via `.gitignore`. In non-git directories or repos without a `.gitignore`, linkspector would scan thousands
 of markdown files inside `node_modules` and appear to hang.
- **Fixes standalone binary crash** — the Bun-compiled binary crashed on `--version` because
`createRequire` couldn't resolve `package.json` from Bun's virtual filesystem. Added a fallback chain so
the binary degrades gracefully. 
- **Adds `PREREQUISITES.md`** — documents Node.js version requirements, system library packages 
(Debian/Ubuntu, Fedora/RHEL), Chromium setup for ARM64, and running as root in containers. Linked from the
 Installation section of the README.
- **Renames `Dockerfile.binary` to `Dockerfile.buildbinary`** — clarifies that this Dockerfile is for
*building* binaries.
- **Adds new `Dockerfile.binary`** — a lightweight Dockerfile that runs linkspector using a pre-built
binary from GitHub Releases. No Node.js or npm required. Supports `LINKSPECTOR_VERSION` build arg and
auto-detects architecture.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information

- The `index.js` change to `package.json` loading is backwards-compatible — `createRequire` is tried first
 (works for npm installs), with `readFileSync` and `{ version: 'unknown' }` as fallbacks. 
- The new `Dockerfile.binary` works with current releases (v0.5.2), though `--version` will show an error 
due to the pre-existing binary bug. Once a new release is cut with the `index.js` fix, it will display the
 version correctly. 
- Test expected link count updated from 44 to 45 to account for the new `PREREQUISITES.md` file.