### PR TITLE
Fixes april 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,13 @@ linkspector check [options]
 
 ### Options
 
-| Flag                  | Description                                                  |
-| --------------------- | ------------------------------------------------------------ |
-| `-c, --config <path>` | Custom configuration file path (default: `.linkspector.yml`) |
-| `-j, --json`          | Output results in RDJSON format                              |
-| `-s, --showstat`      | Display link check statistics                                |
-| `-q, --quiet`         | No output, exit code only                                    |
+| Flag                   | Description                                                  |
+| ---------------------- | ------------------------------------------------------------ |
+| `-c, --config <path>`  | Custom configuration file path (default: `.linkspector.yml`) |
+| `-j, --json`           | Output results in RDJSON format                              |
+| `-s, --showstat`       | Display link check statistics                                |
+| `-q, --quiet`          | No output, exit code only                                    |
+| `-a, --check-archived` | Warn about links to archived GitHub repos                    |
 
 ### Examples
 
@@ -193,6 +194,9 @@ linkspector check -s
 
 # Quiet mode (exit code only, useful in scripts)
 linkspector check -q
+
+# Warn about archived GitHub repos
+linkspector check --check-archived
 ```
 
 ### Output modes
@@ -254,6 +258,7 @@ useGitIgnore: true
 | [`retryCount`](#retry-count)                      | Retry attempts with exponential backoff (default: `3`) | No                         |
 | [`userAgent`](#user-agent)                        | Custom User-Agent string                               | No                         |
 | [`ignoreSslErrors`](#ignore-ssl-errors)           | Skip SSL certificate validation                        | No                         |
+| [`checkGithubArchived`](#check-github-archived)   | Warn about archived GitHub repos                       | No                         |
 
 ### Files to check
 
@@ -395,6 +400,34 @@ ignoreSslErrors: true
 
 > **Warning:** Only enable this for trusted servers (e.g., internal servers with self-signed certificates).
 
+### Check GitHub archived
+
+```yaml
+checkGithubArchived: true
+```
+
+When enabled, Linkspector checks whether GitHub repository links point to archived repos. Archived repos return HTTP 200 (they're still reachable) but are no longer maintained. These are reported as warnings, not errors, so they don't affect the exit code.
+
+Uses the [GitHub API](https://docs.github.com/en/rest/repos/repos#get-a-repository) and requires a `GITHUB_TOKEN` for large repos (see [GitHub Token](#github-token) below).
+
+You can also enable this via the `--check-archived` CLI flag without modifying your config file.
+
+### GitHub Token
+
+Set the `GITHUB_TOKEN` environment variable to authenticate requests to GitHub:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here
+linkspector check
+```
+
+When set, the token is used for:
+
+- **Regular link checking** — Authenticates requests to `github.com` to avoid HTTP 429 (Too Many Requests) rate limiting. This is especially important in CI/CD environments and when checking files with many GitHub links.
+- **Archived repo detection** — Increases the GitHub API rate limit from 60 to 5,000 requests/hour for the `checkGithubArchived` feature.
+
+In GitHub Actions, the token is available automatically as `${{ github.token }}`.
+
 ### Full example
 
 ```yaml
@@ -426,6 +459,7 @@ timeout: 60000
 retryCount: 5
 userAgent: 'MyLinkChecker/1.0'
 ignoreSslErrors: false
+checkGithubArchived: true
 ```
 
 ---

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ program
   .option('-j, --json', 'Output the results in JSON format')
   .option('-s, --showstat', 'Display statistics about the links checked')
   .option('-q, --quiet', 'Suppress all output except errors')
+  .option('-a, --check-archived', 'Warn about links to archived GitHub repos')
   .action(async (cmd) => {
     // Validate that -j and -s options are not used together
     if (cmd.json && cmd.showstat) {
@@ -92,6 +93,7 @@ program
       anchors: 0,
       correctLinks: 0,
       failedLinks: 0,
+      warningLinks: 0,
     }
 
     // JSON results accumulator
@@ -151,7 +153,9 @@ program
                         column: linkStatusObj.position?.start?.column ?? 1,
                       },
                       end: {
-                        line: linkStatusObj.position?.end?.line ?? linkStatusObj.line_number,
+                        line:
+                          linkStatusObj.position?.end?.line ??
+                          linkStatusObj.line_number,
                         column: linkStatusObj.position?.end?.column ?? 1,
                       },
                     },
@@ -165,6 +169,36 @@ program
               renderer.onError(file, linkStatusObj)
             }
             hasErrorLinks = true
+          } else if (linkStatusObj.status === 'warning') {
+            stats.warningLinks++
+            stats.correctLinks++
+            if (cmd.json) {
+              const diagnostic = validateDiagnostic(
+                {
+                  message: `Archived repo: ${linkStatusObj.link}${linkStatusObj.error_message ? ` (${linkStatusObj.error_message})` : ''}`,
+                  location: {
+                    path: file,
+                    range: {
+                      start: {
+                        line: linkStatusObj.line_number,
+                        column: linkStatusObj.position?.start?.column ?? 1,
+                      },
+                      end: {
+                        line:
+                          linkStatusObj.position?.end?.line ??
+                          linkStatusObj.line_number,
+                        column: linkStatusObj.position?.end?.column ?? 1,
+                      },
+                    },
+                  },
+                  severity: 'WARNING',
+                },
+                file
+              )
+              results.diagnostics.push(diagnostic)
+            } else {
+              renderer.onWarning(file, linkStatusObj)
+            }
           } else if (
             linkStatusObj.status === 'alive' ||
             linkStatusObj.status === 'assumed alive'

--- a/index.js
+++ b/index.js
@@ -148,11 +148,11 @@ program
                     range: {
                       start: {
                         line: linkStatusObj.line_number,
-                        column: linkStatusObj.position.start.column,
+                        column: linkStatusObj.position?.start?.column ?? 1,
                       },
                       end: {
-                        line: linkStatusObj.position.end.line,
-                        column: linkStatusObj.position.end.column,
+                        line: linkStatusObj.position?.end?.line ?? linkStatusObj.line_number,
+                        column: linkStatusObj.position?.end?.column ?? 1,
                       },
                     },
                   },

--- a/index.test.js
+++ b/index.test.js
@@ -67,12 +67,12 @@ describe('linkspector index tests', () => {
 
     expect(relativeLinks.length).toBeGreaterThan(0)
     expect(relativeLinkErrors.length).toBe(0)
-    expect(results.length).toBe(45)
+    expect(results.length).toBe(48)
   })
 
   it('linkspector should track statistics correctly when stats option is enabled', () => {
     expect(stats.filesChecked).toBeGreaterThan(0)
-    expect(stats.totalLinks).toBe(45)
+    expect(stats.totalLinks).toBe(48)
     expect(stats.totalLinks).toBe(
       stats.httpLinks +
         stats.fileLinks +

--- a/lib/batch-check-links.js
+++ b/lib/batch-check-links.js
@@ -289,6 +289,7 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
     urlCache = null,
     getBrowser = null,
     fetchSkipDomains = null,
+    checkGithubArchived: checkGithubArchivedOpt = false,
   } = options
   const linkStatusList = []
   const tempArray = []
@@ -345,6 +346,19 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
             method: 'HEAD',
             redirect: followRedirects ? 'follow' : 'manual',
           }
+
+          // Authenticate GitHub requests to avoid 429 rate limiting
+          const githubToken = process.env.GITHUB_TOKEN
+          if (
+            githubToken &&
+            (hostname === 'github.com' || hostname === 'www.github.com')
+          ) {
+            fetchOptions.headers = {
+              ...fetchOptions.headers,
+              Authorization: `Bearer ${githubToken}`,
+            }
+          }
+
           const response = await fetchWithRetry(link.url, fetchOptions, {
             retryCount,
             timeout,
@@ -547,7 +561,91 @@ async function checkHyperlinks(nodes, options = {}, filePath) {
       }
     }
   }
+  if (checkGithubArchivedOpt) {
+    await checkArchivedGithubRepos(linkStatusList)
+  }
+
   return linkStatusList
+}
+
+// Extract owner/repo from a GitHub URL. Returns null if not a repo URL.
+function extractGithubRepo(urlString) {
+  try {
+    const parsed = new url.URL(urlString)
+    if (
+      parsed.hostname !== 'github.com' &&
+      parsed.hostname !== 'www.github.com'
+    ) {
+      return null
+    }
+    const parts = parsed.pathname.split('/').filter(Boolean)
+    if (parts.length < 2) return null
+    return `${parts[0]}/${parts[1]}`
+  } catch {
+    return null
+  }
+}
+
+// Check alive GitHub links for archived repos via the GitHub API
+async function checkArchivedGithubRepos(linkStatusList) {
+  const token = process.env.GITHUB_TOKEN
+
+  // Collect unique repos from alive GitHub links
+  const repoToIndices = new Map()
+  for (let i = 0; i < linkStatusList.length; i++) {
+    const entry = linkStatusList[i]
+    if (entry.status !== 'alive' && entry.status !== 'assumed alive') continue
+    const repo = extractGithubRepo(entry.link)
+    if (!repo) continue
+    if (!repoToIndices.has(repo)) repoToIndices.set(repo, [])
+    repoToIndices.get(repo).push(i)
+  }
+
+  if (repoToIndices.size === 0) return
+
+  const semaphore = new Semaphore(5)
+  const promises = []
+
+  for (const [repo, indices] of repoToIndices) {
+    promises.push(
+      (async () => {
+        await semaphore.acquire()
+        try {
+          const headers = {
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'linkspector',
+          }
+          if (token) {
+            headers['Authorization'] = `Bearer ${token}`
+          }
+          const controller = new AbortController()
+          const timeoutId = setTimeout(() => controller.abort(), 10000)
+
+          const response = await fetch(`https://api.github.com/repos/${repo}`, {
+            headers,
+            signal: controller.signal,
+          })
+          clearTimeout(timeoutId)
+
+          if (response.ok) {
+            const data = await response.json()
+            if (data.archived === true) {
+              for (const idx of indices) {
+                linkStatusList[idx].status = 'warning'
+                linkStatusList[idx].error_message = 'Repository is archived'
+              }
+            }
+          }
+        } catch {
+          // Silently ignore API errors — archive check is best-effort
+        } finally {
+          semaphore.release()
+        }
+      })()
+    )
+  }
+
+  await Promise.all(promises)
 }
 
 export { checkHyperlinks }

--- a/lib/check-file-links.js
+++ b/lib/check-file-links.js
@@ -85,13 +85,20 @@ function checkFileExistence(link, file) {
                   : slugger.slug(headingText)
             headingNodes.add(headingId)
           } else if (node.type === 'html') {
-            // Match both name and id attributes in HTML anchors
-            const anchorNameMatch = node.value.match(
-              /<a\s+.*?(name|id)="(.+?)".*?>/
+            // Match id attribute on any HTML element (a, span, div, etc.)
+            // including self-closing tags like <span id="foo"/>
+            const idMatch = node.value.match(
+              /<\w+\s+[^>]*?id="(.+?)"[^>]*?\/?>/
             )
-            if (anchorNameMatch) {
-              const anchorName = anchorNameMatch[2]
-              headingNodes.add(anchorName)
+            if (idMatch) {
+              headingNodes.add(idMatch[1])
+            }
+            // Also match name attribute on <a> tags
+            const nameMatch = node.value.match(
+              /<a\s+[^>]*?name="(.+?)"[^>]*?\/?>/
+            )
+            if (nameMatch) {
+              headingNodes.add(nameMatch[1])
             }
           }
         })

--- a/lib/renderers/plain-renderer.js
+++ b/lib/renderers/plain-renderer.js
@@ -32,6 +32,17 @@ export function createPlainRenderer(cmd) {
       spinner.start(`Checking ${currentFile}...`)
     },
 
+    onWarning(file, linkStatusObj) {
+      if (cmd.quiet) return
+      spinner.stop()
+      console.log(
+        kleur.yellow(
+          `${file}:${linkStatusObj.line_number}:${linkStatusObj.position?.start?.column ?? '?'}: WARNING ${linkStatusObj.link} ${linkStatusObj.error_message || 'Repository is archived'}`
+        )
+      )
+      spinner.start(`Checking ${currentFile}...`)
+    },
+
     onFileComplete(_file, _results, _stats) {
       // Nothing extra in plain mode — errors already printed inline
     },
@@ -89,6 +100,14 @@ export function createPlainRenderer(cmd) {
       console.log(
         `\u2502 \u{1F6AB} ${kleur.bold('Failed links')}               \u2502 ${kleur.red(padNumber(stats.failedLinks))} \u2502`
       )
+      if (stats.warningLinks > 0) {
+        console.log(
+          '\u251C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524'
+        )
+        console.log(
+          `\u2502 \u26A0\uFE0F  ${kleur.bold('Archived repos (warning)')}   \u2502 ${kleur.yellow(padNumber(stats.warningLinks))} \u2502`
+        )
+      }
       console.log(
         '\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518'
       )

--- a/lib/renderers/plain-renderer.js
+++ b/lib/renderers/plain-renderer.js
@@ -26,7 +26,7 @@ export function createPlainRenderer(cmd) {
       spinner.stop()
       console.log(
         kleur.red(
-          `${file}:${linkStatusObj.line_number}:${linkStatusObj.position.start.column}: \u{1F6AB} ${linkStatusObj.link} Status:${linkStatusObj.status_code}${linkStatusObj.error_message ? ` ${linkStatusObj.error_message}` : ' Cannot reach link'}`
+          `${file}:${linkStatusObj.line_number}:${linkStatusObj.position?.start?.column ?? '?'}: \u{1F6AB} ${linkStatusObj.link} Status:${linkStatusObj.status_code}${linkStatusObj.error_message ? ` ${linkStatusObj.error_message}` : ' Cannot reach link'}`
         )
       )
       spinner.start(`Checking ${currentFile}...`)

--- a/lib/renderers/tui-renderer.js
+++ b/lib/renderers/tui-renderer.js
@@ -155,7 +155,7 @@ function StatusLine({ filesChecked, totalFiles, currentFile, totalLinks }) {
 // Single error line
 function ErrorLine({ file, linkStatusObj }) {
   const line = linkStatusObj.line_number
-  const col = linkStatusObj.position.start.column
+  const col = linkStatusObj.position?.start?.column ?? '?'
   const link = linkStatusObj.link
   const status = linkStatusObj.status_code
   const msg = linkStatusObj.error_message || 'Cannot reach link'

--- a/lib/renderers/tui-renderer.js
+++ b/lib/renderers/tui-renderer.js
@@ -173,6 +173,53 @@ function ErrorLine({ file, linkStatusObj }) {
   )
 }
 
+// Single warning line (archived repo)
+function WarningLine({ file, linkStatusObj }) {
+  const line = linkStatusObj.line_number
+  const col = linkStatusObj.position?.start?.column ?? '?'
+  const link = linkStatusObj.link
+  const msg = linkStatusObj.error_message || 'Repository is archived'
+
+  return h(
+    Box,
+    { paddingLeft: 2 },
+    h(Text, { dimColor: true }, `L${line}:${col}`),
+    h(Text, null, '  '),
+    h(Text, { color: 'yellow' }, figures.warning),
+    h(Text, null, ' '),
+    h(Text, null, truncate(link, 50)),
+    h(Text, null, '  '),
+    h(Text, { color: 'yellow', dimColor: true }, msg)
+  )
+}
+
+// Group warnings by file
+function WarningGroup({ warnings }) {
+  if (warnings.length === 0) return null
+
+  const grouped = new Map()
+  for (const w of warnings) {
+    if (!grouped.has(w.file)) grouped.set(w.file, [])
+    grouped.get(w.file).push(w.linkStatusObj)
+  }
+
+  const elements = []
+  for (const [file, links] of grouped) {
+    elements.push(
+      h(
+        Box,
+        { key: `wfile-${file}`, flexDirection: 'column', marginTop: 1 },
+        h(Text, { bold: true, color: 'white' }, `  ${file}`),
+        ...links.map((ls, i) =>
+          h(WarningLine, { key: `${file}-w${i}`, file, linkStatusObj: ls })
+        )
+      )
+    )
+  }
+
+  return h(Box, { flexDirection: 'column' }, ...elements)
+}
+
 // Group errors by file
 function ErrorGroup({ errors }) {
   if (errors.length === 0) return null
@@ -304,6 +351,14 @@ function SummaryBar({ stats, elapsed, hasErrors }) {
         )
       : h(Text, { dimColor: true }, `${figures.cross} ${broken} broken`),
     h(Text, { dimColor: true }, '  '),
+    stats.warningLinks > 0
+      ? h(
+          Text,
+          { color: 'yellow' },
+          `${figures.warning} ${stats.warningLinks} archived`
+        )
+      : null,
+    stats.warningLinks > 0 ? h(Text, { dimColor: true }, '  ') : null,
     h(Text, { dimColor: true }, `${figures.circleFilled} ${skipped} skipped`),
     h(Text, { dimColor: true }, `  ${figures.line}  ${files} files in ${secs}s`)
   )
@@ -320,6 +375,9 @@ function StatsTable({ stats }) {
     ['Anchors/IDs', stats.anchors, 'cyan'],
     ['Working links', stats.correctLinks, 'green'],
     ['Failed links', stats.failedLinks, 'red'],
+    ...(stats.warningLinks > 0
+      ? [['Archived repos (warning)', stats.warningLinks, 'yellow']]
+      : []),
   ]
 
   return h(
@@ -356,6 +414,7 @@ function App({ bus, version, showStats }) {
       failedLinks: 0,
     },
     errors: [],
+    warnings: [],
     done: false,
     hasErrors: false,
     elapsed: 0,
@@ -384,6 +443,13 @@ function App({ bus, version, showStats }) {
         ...s,
         errors: [...s.errors, { file, linkStatusObj }],
         hasErrors: true,
+      }))
+    })
+
+    bus.on('warning', (file, linkStatusObj) => {
+      setState((s) => ({
+        ...s,
+        warnings: [...s.warnings, { file, linkStatusObj }],
       }))
     })
 
@@ -515,6 +581,11 @@ function App({ bus, version, showStats }) {
     // Errors grouped by file
     state.errors.length > 0 ? h(ErrorGroup, { errors: state.errors }) : null,
 
+    // Warnings grouped by file (archived repos)
+    state.warnings.length > 0
+      ? h(WarningGroup, { warnings: state.warnings })
+      : null,
+
     // Stats table (if requested)
     showStats ? h(StatsTable, { stats: state.stats }) : null,
 
@@ -581,6 +652,10 @@ export function createTuiRenderer(cmd, version) {
 
     onError(file, linkStatusObj) {
       bus.emit('error', file, linkStatusObj)
+    },
+
+    onWarning(file, linkStatusObj) {
+      bus.emit('warning', file, linkStatusObj)
     },
 
     onFileComplete(file, results, stats) {

--- a/lib/update-linkstatus-obj.js
+++ b/lib/update-linkstatus-obj.js
@@ -70,10 +70,12 @@ function updateLinkStatusObj(astNodes, linkStatus) {
     }
   })
   updatedLinkStatus.sort((a, b) => {
-    if (a.position.start.line === b.position.start.line) {
-      return a.position.start.column - b.position.start.column
+    const aLine = a.position?.start?.line ?? 0
+    const bLine = b.position?.start?.line ?? 0
+    if (aLine === bLine) {
+      return (a.position?.start?.column ?? 0) - (b.position?.start?.column ?? 0)
     }
-    return a.position.start.line - b.position.start.line
+    return aLine - bLine
   })
   return updatedLinkStatus
 }

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -51,6 +51,7 @@ async function validateConfig(config) {
       retryCount: Joi.number().integer().min(0).max(10),
       userAgent: Joi.string(),
       ignoreSslErrors: Joi.boolean(),
+      checkGithubArchived: Joi.boolean(),
     }).or('files', 'dirs')
 
     // Validate the config against the schema

--- a/linkspector.js
+++ b/linkspector.js
@@ -135,6 +135,11 @@ export async function* linkspector(configFile, cmd) {
     }
   }
 
+  // Merge CLI flag for archived repo checking
+  if (cmd.checkArchived) {
+    config.checkGithubArchived = true
+  }
+
   // Prepare the list of files to check
   let filesToCheck = prepareFilesList(config)
 

--- a/test/fixtures/archived-repos/archived-repos.md
+++ b/test/fixtures/archived-repos/archived-repos.md
@@ -1,0 +1,2 @@
+[Archived Repo](https://github.com/gaurav-nelson/github-action-markdown-link-check)
+[Active Repo](https://github.com/UmbrellaDocs/linkspector)

--- a/test/fixtures/archived-repos/archived-repos.test.js
+++ b/test/fixtures/archived-repos/archived-repos.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { linkspector } from '../../../linkspector.js'
+
+describe('GitHub archived repo detection', () => {
+  it('should warn about archived repos when checkGithubArchived is enabled', async () => {
+    const configFile = 'test/fixtures/archived-repos/config-archived.yml'
+    const cmd = { json: true }
+    const results = []
+
+    for await (const item of linkspector(configFile, cmd)) {
+      if (item.type === 'meta') continue
+      for (const linkStatusObj of item.result) {
+        results.push(linkStatusObj)
+      }
+    }
+
+    const archivedLink = results.find(
+      (r) =>
+        r.link ===
+        'https://github.com/gaurav-nelson/github-action-markdown-link-check'
+    )
+    const activeLink = results.find(
+      (r) => r.link === 'https://github.com/UmbrellaDocs/linkspector'
+    )
+
+    expect(archivedLink).toBeDefined()
+    expect(archivedLink.status).toBe('warning')
+    expect(archivedLink.error_message).toBe('Repository is archived')
+
+    expect(activeLink).toBeDefined()
+    expect(activeLink.status).toBe('alive')
+  })
+
+  it('should not warn when checkGithubArchived is not enabled', async () => {
+    const configFile = 'test/fixtures/archived-repos/config-archived.yml'
+    const cmd = { json: true }
+    const results = []
+
+    // Override: read config but don't set checkGithubArchived
+    // We use a separate config without checkGithubArchived
+    for await (const item of linkspector(
+      'test/fixtures/archived-repos/config-no-archived.yml',
+      cmd
+    )) {
+      if (item.type === 'meta') continue
+      for (const linkStatusObj of item.result) {
+        results.push(linkStatusObj)
+      }
+    }
+
+    const archivedLink = results.find(
+      (r) =>
+        r.link ===
+        'https://github.com/gaurav-nelson/github-action-markdown-link-check'
+    )
+
+    expect(archivedLink).toBeDefined()
+    expect(archivedLink.status).toBe('alive')
+  })
+})

--- a/test/fixtures/archived-repos/config-archived.yml
+++ b/test/fixtures/archived-repos/config-archived.yml
@@ -1,0 +1,3 @@
+files:
+  - test/fixtures/archived-repos/archived-repos.md
+checkGithubArchived: true

--- a/test/fixtures/archived-repos/config-no-archived.yml
+++ b/test/fixtures/archived-repos/config-no-archived.yml
@@ -1,0 +1,2 @@
+files:
+  - test/fixtures/archived-repos/archived-repos.md

--- a/test/fixtures/markdown/with-html-anchors-id/html-anchor-id.md
+++ b/test/fixtures/markdown/with-html-anchors-id/html-anchor-id.md
@@ -4,6 +4,14 @@ This is a paragraph in the first file in a first level heading.
 
 Anchor with `id` <a id="custom-id-with-id"></a>
 
+Self-closing span anchor <span id="figure-1"/>
+
+Div anchor <div id="section-start"></div>
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vel mauris sit amet ipsum venenatis placerat.
 
 Link to anchor with `id` [Link to custom id with id](#custom-id-with-id).
+
+Link to span anchor [Figure 1](#figure-1).
+
+Link to div anchor [Section start](#section-start).

--- a/test/fixtures/markdown/with-html-anchors-id/markdown-with-html-anchors-id.test.js
+++ b/test/fixtures/markdown/with-html-anchors-id/markdown-with-html-anchors-id.test.js
@@ -37,6 +37,8 @@ test('linkspector should check HTML encoded section links using ID attribute', a
 
   // Test expectations for link checks
   expect(hasErrorLinks).toBe(false)
-  expect(results.length).toBe(1)
-  expect(results[0].status).toBe('alive')
+  expect(results.length).toBe(3)
+  expect(results[0].status).toBe('alive') // <a id="...">
+  expect(results[1].status).toBe('alive') // <span id="..."/>
+  expect(results[2].status).toBe('alive') // <div id="...">
 })


### PR DESCRIPTION
This PR includes three changes: 
 
1. **Malformed link error handling** — Links without position data (e.g., bare-bracket links like `[text]`
 without a URL) caused runtime crashes when accessing `position.start.column` on `undefined`. Added
null-safe optional chaining across all code paths that access position data.

2. **Archived GitHub repo detection** — Archived GitHub repos return HTTP 200, so linkspector reports them
 as "alive." This adds an opt-in check via the GitHub API (`GET /repos/{owner}/{repo}`) that warns users
when links point to archived repositories. Introduces a new `warning` status that is informational only 
and does not affect the exit code.

 - Enable via `checkGithubArchived: true` in config or `--check-archived` / `-a` CLI flag 
 - Uses `GITHUB_TOKEN` env var for higher API rate limits (5,000/hr vs 60/hr)
 - Warning output in all three renderers (JSON/plain/TUI) 

3. **GitHub request authentication** — When `GITHUB_TOKEN` is set, linkspector now adds it as an
`Authorization: Bearer` header on all fetch requests to `github.com`. This prevents HTTP 429 (Too Many
Requests) rate limiting, especially in CI/CD environments. Addresses
[action-linkspector#43](https://github.com/UmbrellaDocs/action-linkspector/issues/43).

4. **HTML element ID detection for section links** — The anchor detection regex only matched `<a>` tags,
so elements like `<span id="figure-1"/>` or `<div id="section-start">` were not recognized as valid link
targets, causing false positive errors for fragment links.

Fixes #127
Fixes #119
Related:
[UmbrellaDocs/action-linkspector#43](https://github.com/UmbrellaDocs/action-linkspector/issues/43)

## Type of Change 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update 

## Checklist:

- [x] I have performed a self-review of my own code 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Information 

- The `GITHUB_TOKEN` authentication for regular link checking requires no user action in GitHub Actions — 
the token is already available in the environment automatically.
- The `action-linkspector` repo will need to bump the pinned linkspector version in `script.sh` to pick up
 these changes. 
- All 43 tests pass (20 test files), including 2 new test files for archived repo detection and updated
tests for HTML anchor ID detection.
