### PR TITLE
fix: handle same-document navigations in processLink and add regression tests for anchor links

### DIFF
--- a/lib/batch-check-links.js
+++ b/lib/batch-check-links.js
@@ -75,11 +75,28 @@ async function processLink(
           header.url.some((urlPattern) => link.url.includes(urlPattern))
         )?.headers || {}
 
-      const response = await page.goto(link.url, {
+      let response = await page.goto(link.url, {
         waitUntil: 'load',
         headers,
         timeout,
       })
+
+      // page.goto() returns null for same-document navigations, e.g. when a
+      // reused page already has this URL loaded and only the hash differs.
+      // Reset the page and navigate again to get a real response.
+      if (!response) {
+        await page.goto('about:blank')
+        response = await page.goto(link.url, {
+          waitUntil: 'load',
+          headers,
+          timeout,
+        })
+      }
+
+      if (!response) {
+        throw new Error('Navigation did not return a response.')
+      }
+
       statusCode = response.status()
       const redirectChain = response.request().redirectChain()
 

--- a/test/fixtures/same-page-anchors/config-same-page-anchors.yml
+++ b/test/fixtures/same-page-anchors/config-same-page-anchors.yml
@@ -1,0 +1,2 @@
+files:
+  - test/fixtures/same-page-anchors/same-page-anchors.md

--- a/test/fixtures/same-page-anchors/same-page-anchors.md
+++ b/test/fixtures/same-page-anchors/same-page-anchors.md
@@ -1,0 +1,20 @@
+# Same Page Anchor Links
+
+This file contains more than 10 links to the same HTML document that only
+differ in their anchors (regression fixture for issue 177).
+
+- [Section 1](http://localhost:3210/page.html#section-1)
+- [Section 2](http://localhost:3210/page.html#section-2)
+- [Section 3](http://localhost:3210/page.html#section-3)
+- [Section 4](http://localhost:3210/page.html#section-4)
+- [Section 5](http://localhost:3210/page.html#section-5)
+- [Section 6](http://localhost:3210/page.html#section-6)
+- [Section 7](http://localhost:3210/page.html#section-7)
+- [Section 8](http://localhost:3210/page.html#section-8)
+- [Section 9](http://localhost:3210/page.html#section-9)
+- [Section 10](http://localhost:3210/page.html#section-10)
+- [Section 11](http://localhost:3210/page.html#section-11)
+- [Section 12](http://localhost:3210/page.html#section-12)
+- [Section 13](http://localhost:3210/page.html#section-13)
+- [Section 14](http://localhost:3210/page.html#section-14)
+- [Section 15](http://localhost:3210/page.html#section-15)

--- a/test/fixtures/same-page-anchors/same-page-anchors.test.js
+++ b/test/fixtures/same-page-anchors/same-page-anchors.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { linkspector } from '../../../linkspector.js'
+import path from 'path'
+import http from 'http'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const configFile = path.join(__dirname, 'config-same-page-anchors.yml')
+
+const PORT = 3210
+const HOST = 'localhost'
+
+let server
+
+const pageHtml = `<!DOCTYPE html>
+<html>
+<body>
+${Array.from(
+  { length: 15 },
+  (_, i) => `<h2 id="section-${i + 1}">Section ${i + 1}</h2>`
+).join('\n')}
+</body>
+</html>`
+
+const serverHandler = (req, res) => {
+  // Reject HEAD requests so the fast fetch pass fails and all links
+  // fall through to the Puppeteer pass, like servers that block HEAD.
+  if (req.method === 'HEAD') {
+    res.writeHead(405, { 'Content-Type': 'text/plain' })
+    res.end()
+    return
+  }
+  if (req.url === '/page.html') {
+    res.writeHead(200, { 'Content-Type': 'text/html' })
+    res.end(pageHtml)
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('Not Found')
+  }
+}
+
+// Regression test for https://github.com/UmbrellaDocs/linkspector/issues/177
+// More than 10 links to the same HTML document that only differ in their
+// anchors made Puppeteer reuse a pooled page that already had the document
+// loaded. page.goto() returns null for such same-URL-different-hash
+// navigations, producing "Cannot read properties of null (reading 'status')".
+describe('more than 10 links to the same document with different anchors', () => {
+  let results = []
+
+  beforeAll(async () => {
+    server = http.createServer(serverHandler)
+    await new Promise((resolve) => server.listen(PORT, HOST, resolve))
+
+    for await (const item of linkspector(configFile, {})) {
+      if (item.type === 'meta') continue
+      results.push(...item.result)
+    }
+  }, 60000)
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  it('checks all anchored links', () => {
+    expect(results.length).toBe(15)
+  })
+
+  it('does not fail with "Cannot read properties of null"', () => {
+    const nullErrors = results.filter(
+      (r) =>
+        r.error_message &&
+        r.error_message.includes('Cannot read properties of null')
+    )
+    expect(nullErrors).toEqual([])
+  })
+
+  it('reports every anchored link as alive with status 200', () => {
+    for (const result of results) {
+      expect(result.status, `${result.link}: ${result.error_message}`).toBe(
+        'alive'
+      )
+      expect(result.status_code).toBe(200)
+    }
+  })
+})


### PR DESCRIPTION
## Description

When the fast HTTP pass can't verify a link, it falls through to the Puppeteer pass, which reuses pages from a PagePool capped at 10 pages. With more than 10 links to the same HTML document, a link inevitably gets a recycled page that already has that document loaded. Navigating to the same URL with only a different #anchor is a same-document navigation, and Puppeteer's `page.goto()` documentedly returns null for those, so `response.status()` at `lib/batch-check-links.js:83` threw `Cannot read properties of null (reading 'status')`, which got reported as a link error with `status_code: null`.

Thank you @ralfhandl for finding the actual bug.

Fixes #177 

## Changes

- `lib/batch-check-links.js` — in `processLink`, if `page.goto()` returns `null`, reset the page to `about:blank` and navigate
  again, which forces a full navigation and yields a real response. If it's somehow still null, throw a descriptive error
  instead of the opaque TypeError.
- `test/fixtures/same-page-anchors/`: regression test for 177: a local server that rejects HEAD (forcing the Puppeteer
  pass, like rfc-editor.org) serving one HTML page, plus a markdown fixture with 15 links to it differing only by anchor.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
